### PR TITLE
feat: Bird API 구현 완료

### DIFF
--- a/src/main/java/com/saerok/showing/api/domain/bird/controller/BirdController.java
+++ b/src/main/java/com/saerok/showing/api/domain/bird/controller/BirdController.java
@@ -1,8 +1,14 @@
 package com.saerok.showing.api.domain.bird.controller;
 
+import com.saerok.showing.api.domain.bird.dto.response.BirdDetailResponse;
 import com.saerok.showing.api.domain.bird.service.BirdService;
+import com.saerok.showing.api.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -13,4 +19,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class BirdController {
 
     private final BirdService birdService;
+
+    @Operation(
+        summary = "새 단건 조회",
+        description = "[모든 Role 가능] birdId로 새의 상세 정보를 조회합니다."
+    )
+    @PreAuthorize("hasRole('MEMBER')")
+    @GetMapping("")
+    public ApiResponse<BirdDetailResponse> getBird(@PathVariable Long birdId) {
+        BirdDetailResponse bird = birdService.getBird(birdId);
+        return ApiResponse.success(bird);
+    }
 }

--- a/src/main/java/com/saerok/showing/api/domain/bird/controller/BirdController.java
+++ b/src/main/java/com/saerok/showing/api/domain/bird/controller/BirdController.java
@@ -25,7 +25,7 @@ public class BirdController {
         description = "[모든 Role 가능] birdId로 새의 상세 정보를 조회합니다."
     )
     @PreAuthorize("hasRole('MEMBER')")
-    @GetMapping("")
+    @GetMapping("/{birdId}")
     public ApiResponse<BirdDetailResponse> getBird(@PathVariable Long birdId) {
         BirdDetailResponse bird = birdService.getBird(birdId);
         return ApiResponse.success(bird);

--- a/src/main/java/com/saerok/showing/api/domain/bird/dto/response/BirdDetailResponse.java
+++ b/src/main/java/com/saerok/showing/api/domain/bird/dto/response/BirdDetailResponse.java
@@ -1,0 +1,35 @@
+package com.saerok.showing.api.domain.bird.dto.response;
+
+import com.saerok.showing.api.domain.bird.entity.Bird;
+import com.saerok.showing.api.domain.theme.dto.response.ThemeSummaryResponse;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class BirdDetailResponse {
+
+    private Long id;
+
+    private String nameKr;
+
+    private String nameEn;
+
+    private String description;
+
+    private String birdImage;
+
+    private List<ThemeSummaryResponse> themes;
+
+    public static BirdDetailResponse toDto(Bird bird, List<ThemeSummaryResponse> themes) {
+        return BirdDetailResponse.builder()
+            .id(bird.getId())
+            .nameKr(bird.getNameKr())
+            .nameEn(bird.getNameEn())
+            .description(bird.getDescription())
+            .birdImage(bird.getBirdImage())
+            .themes(themes)
+            .build();
+    }
+}

--- a/src/main/java/com/saerok/showing/api/domain/bird/service/BirdService.java
+++ b/src/main/java/com/saerok/showing/api/domain/bird/service/BirdService.java
@@ -1,12 +1,33 @@
 package com.saerok.showing.api.domain.bird.service;
 
+import com.saerok.showing.api.domain.bird.dto.response.BirdDetailResponse;
+import com.saerok.showing.api.domain.bird.entity.Bird;
 import com.saerok.showing.api.domain.bird.repository.BirdRepository;
+import com.saerok.showing.api.domain.birdTheme.service.BirdThemeService;
+import com.saerok.showing.api.domain.theme.dto.response.ThemeSummaryResponse;
+import com.saerok.showing.api.global.exception.ErrorCode;
+import com.saerok.showing.api.global.exception.ShowingException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class BirdService {
 
     private final BirdRepository birdRepository;
+    private final BirdThemeService birdThemeService;
+
+    @Transactional(readOnly = true)
+    public BirdDetailResponse getBird(Long birdId){
+        Bird bird = findById(birdId);
+        List<ThemeSummaryResponse> themes = birdThemeService.getThemeNames(birdId);
+        return BirdDetailResponse.toDto(bird, themes);
+    }
+
+    private Bird findById(Long birdId) {
+        return birdRepository.findById(birdId)
+            .orElseThrow(()-> ShowingException.from(ErrorCode.BIRD_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/saerok/showing/api/domain/birdTheme/respository/BirdThemeRepository.java
+++ b/src/main/java/com/saerok/showing/api/domain/birdTheme/respository/BirdThemeRepository.java
@@ -2,6 +2,7 @@ package com.saerok.showing.api.domain.birdTheme.respository;
 
 import com.saerok.showing.api.domain.bird.entity.Bird;
 import com.saerok.showing.api.domain.birdTheme.entity.BirdTheme;
+import com.saerok.showing.api.domain.theme.entity.Theme;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -13,4 +14,7 @@ public interface BirdThemeRepository extends JpaRepository<BirdTheme, Long> {
 
     @Query("SELECT bt.bird FROM BirdTheme bt WHERE bt.theme.id = :themeId")
     List<Bird> findBirdsByThemeId(@Param("themeId") Long themeId);
+
+    @Query("SELECT bt.theme FROM BirdTheme bt WHERE bt.bird.id = :birdId")
+    List<Theme> findThemesByBirdId(@Param("birdId") Long birdId);
 }

--- a/src/main/java/com/saerok/showing/api/domain/birdTheme/service/BirdThemeService.java
+++ b/src/main/java/com/saerok/showing/api/domain/birdTheme/service/BirdThemeService.java
@@ -3,6 +3,8 @@ package com.saerok.showing.api.domain.birdTheme.service;
 import com.saerok.showing.api.domain.bird.dto.response.BirdSummaryResponse;
 import com.saerok.showing.api.domain.bird.entity.Bird;
 import com.saerok.showing.api.domain.birdTheme.respository.BirdThemeRepository;
+import com.saerok.showing.api.domain.theme.dto.response.ThemeSummaryResponse;
+import com.saerok.showing.api.domain.theme.entity.Theme;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +22,14 @@ public class BirdThemeService {
         List<Bird> birds = birdThemeRepository.findBirdsByThemeId(themeId);
         return birds.stream()
             .map(BirdSummaryResponse::toDto)
+            .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public List<ThemeSummaryResponse> getThemeNames(Long birdId) {
+        List<Theme> themes = birdThemeRepository.findThemesByBirdId(birdId);
+        return themes.stream()
+            .map(ThemeSummaryResponse::toDto)
             .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/saerok/showing/api/domain/theme/dto/response/ThemeSummaryResponse.java
+++ b/src/main/java/com/saerok/showing/api/domain/theme/dto/response/ThemeSummaryResponse.java
@@ -10,12 +10,12 @@ public class ThemeSummaryResponse {
 
     private Long id;
 
-    private String title;
+    private String originTitle;
 
     public static ThemeSummaryResponse toDto(Theme theme) {
         return ThemeSummaryResponse.builder()
             .id(theme.getId())
-            .title(theme.getTitle())
+            .originTitle(theme.getOriginTitle())
             .build();
     }
 }

--- a/src/main/java/com/saerok/showing/api/domain/theme/dto/response/ThemeSummaryResponse.java
+++ b/src/main/java/com/saerok/showing/api/domain/theme/dto/response/ThemeSummaryResponse.java
@@ -1,0 +1,21 @@
+package com.saerok.showing.api.domain.theme.dto.response;
+
+import com.saerok.showing.api.domain.theme.entity.Theme;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ThemeSummaryResponse {
+
+    private Long id;
+
+    private String title;
+
+    public static ThemeSummaryResponse toDto(Theme theme) {
+        return ThemeSummaryResponse.builder()
+            .id(theme.getId())
+            .title(theme.getTitle())
+            .build();
+    }
+}

--- a/src/main/java/com/saerok/showing/api/global/exception/ErrorCode.java
+++ b/src/main/java/com/saerok/showing/api/global/exception/ErrorCode.java
@@ -36,6 +36,7 @@ public enum ErrorCode {
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다."),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     THEME_NOT_FOUND(HttpStatus.NOT_FOUND, "테마를 찾을 수 없습니다."),
+    BIRD_NOT_FOUND(HttpStatus.NOT_FOUND, "새를 찾을 수 없습니다."),
     PROFILE_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "프로필 이미지를 찾을 수 없습니다."),
     TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "토큰을 찾을 수 없습니다."),
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "리뷰를 찾을 수 없습니다."),


### PR DESCRIPTION
## ⭐️ Overview

> #11 

BIrd의 상세 정보를 조회할 수 있는 기능을 구현했습니다.

## 🔧 Tasks

- 새 단건 조회 API 구현

## 📝 Additional Notes

- 새가 어떤 테마에 출몰하는지 확인할 수 있도록, 관련 테마 리스트를 함께 반환합니다.
- 새 데이터가 추가됨에 따라 `Theme` 조회 관련 기능도 함께 테스트하였습니다.

## 📸 Screenshot

### Bird 단건 조회 (예: 흑두루미 → 순천만 습지, 철원 평야에서 출몰)

<img width="600" alt="Bird1" src="https://github.com/user-attachments/assets/fa9ac14d-ebc1-426b-b457-6139e8570992" />

<img width="600" alt="Bird2" src="https://github.com/user-attachments/assets/77513f04-2d72-4cd8-be3f-e195b274117b" />
