### PR TITLE
feat: AWS S3 연동 및 도메인별 파일 업로드 기능 구현 완료

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,6 +61,10 @@ jobs:
           SPRINGDOC_API_DOCS_PATH: ${{ secrets.SPRINGDOC_API_DOCS_PATH }}
           SPRINGDOC_SWAGGER_UI_PATH: ${{ secrets.SPRINGDOC_SWAGGER_UI_PATH }}
           SPRINGDOC_PACKAGES_TO_SCAN: ${{ secrets.SPRINGDOC_PACKAGES_TO_SCAN }}
+          BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
+          S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
+          S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
+          S3_REGION: ${{ secrets.S3_REGION }}
 
       # Docker 이미지 빌드
       - name: docker image build

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,10 @@ dependencies {
 	implementation 'org.postgresql:postgresql'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+	// AWS S3
+	implementation platform('software.amazon.awssdk:bom:2.25.19')
+	implementation 'software.amazon.awssdk:s3'
+
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/saerok/showing/api/global/config/S3Config.java
+++ b/src/main/java/com/saerok/showing/api/global/config/S3Config.java
@@ -1,0 +1,31 @@
+package com.saerok.showing.api.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+    @Value("${S3_ACCESS_KEY}")
+    private String accessKey;
+
+    @Value("${S3_SECRET_KEY}")
+    private String secretKey;
+
+    @Value("${S3_REGION}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
+        return S3Client.builder()
+            .region(Region.of(region))
+            .credentialsProvider(StaticCredentialsProvider.create(credentials))
+            .build();
+    }
+}

--- a/src/main/java/com/saerok/showing/api/global/file/controller/FileController.java
+++ b/src/main/java/com/saerok/showing/api/global/file/controller/FileController.java
@@ -1,0 +1,105 @@
+package com.saerok.showing.api.global.file.controller;
+
+import com.saerok.showing.api.global.file.dto.FileUploadResponse;
+import com.saerok.showing.api.global.file.service.FileService;
+import com.saerok.showing.api.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/v1/file")
+@RequiredArgsConstructor
+@Tag(name = "File", description = "파일 관리")
+public class FileController {
+
+    private final FileService fileService;
+
+    @Operation(
+        summary = "탐조 사진 업로드",
+        description = """
+            [MEMBER 이상 가능] 탐조하며 찍은 사진을 업로드합니다.<br>
+            한장만 업로드 가능하며 5MB를 넘길 수 없습니다.<br>
+            가능한 확장자는 ".jpg", ".jpeg", ".png", ".gif", ".pdf"입니다.
+            """)
+    @PreAuthorize("hasRole('MEMBER')")
+    @PostMapping(
+        value = "/bird",
+        consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+        produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ApiResponse<FileUploadResponse> uploadBirdImage(
+        @RequestParam(name = "multipartFile") MultipartFile multipartFile
+    ) {
+        FileUploadResponse fileUploadResponse = fileService.uploadFile(multipartFile, "bird/");
+        return ApiResponse.success(fileUploadResponse);
+    }
+
+    @Operation(
+        summary = "장소 사진 업로드",
+        description = """
+            [ADMIN 이상 가능] 장소(HOTEL, THEME) 사진을 업로드합니다.<br>
+            여러 장 업로드 가능하며 각 파일은 5MB를 넘길 수 없습니다.<br>
+            가능한 확장자는 ".jpg", ".jpeg", ".png", ".gif", ".pdf"입니다.
+            """)
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping(
+        value = "/place",
+        consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+        produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ApiResponse<List<FileUploadResponse>> uploadPlaceImage(
+        @RequestParam(name = "multipartFile") List<MultipartFile> multipartFiles
+    ) {
+        List<FileUploadResponse> fileUploadResponse = fileService.uploadFiles(multipartFiles, "place/");
+        return ApiResponse.success(fileUploadResponse);
+    }
+
+    @Operation(
+        summary = "리뷰 사진 업로드",
+        description = """
+            [MEMBER 이상 가능] 리뷰 사진을 업로드합니다.<br>
+            여러 장 업로드 가능하며 각 파일은 5MB를 넘길 수 없습니다.<br>
+            가능한 확장자는 ".jpg", ".jpeg", ".png", ".gif", ".pdf"입니다.
+            """)
+    @PreAuthorize("hasRole('MEMBER')")
+    @PostMapping(
+        value = "/review",
+        consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+        produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ApiResponse<List<FileUploadResponse>> uploadReviewImage(
+        @RequestParam(name = "multipartFile") List<MultipartFile> multipartFiles
+    ) {
+        List<FileUploadResponse> fileUploadResponses = fileService.uploadFiles(multipartFiles, "review/");
+        return ApiResponse.success(fileUploadResponses);
+    }
+
+    @Operation(
+        summary = "프로필 사진 업로드",
+        description = """
+            [MEMBER 이상 가능] 탐조하며 찍은 사진을 업로드합니다.<br>
+            여러 장 업로드 가능하며 각 파일은 5MB를 넘길 수 없습니다.<br>
+            가능한 확장자는 ".jpg", ".jpeg", ".png", ".gif", ".pdf"입니다.
+            """)
+    @PreAuthorize("hasRole('MEMBER')")
+    @PostMapping(
+        value = "/profile",
+        consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+        produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ApiResponse<List<FileUploadResponse>> uploadProfileImage(
+        @RequestParam(name = "multipartFile") List<MultipartFile> multipartFiles
+    ) {
+        List<FileUploadResponse> fileUploadResponses = fileService.uploadFiles(multipartFiles, "profile/");
+        return ApiResponse.success(fileUploadResponses);
+    }
+}

--- a/src/main/java/com/saerok/showing/api/global/file/dto/ExternalFileResponse.java
+++ b/src/main/java/com/saerok/showing/api/global/file/dto/ExternalFileResponse.java
@@ -1,0 +1,31 @@
+package com.saerok.showing.api.global.file.dto;
+
+import com.saerok.showing.api.global.file.entity.UploadedFile;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ExternalFileResponse {
+
+    private String fileUrl;
+
+    private Long fileSize;
+
+    private String contentType;
+
+    public static ExternalFileResponse toDto(UploadedFile uploadedFile) {
+        return ExternalFileResponse.builder()
+            .fileUrl(uploadedFile.getFileUrl())
+            .fileSize(uploadedFile.getFileSize())
+            .contentType(uploadedFile.getContentType())
+            .build();
+    }
+
+    public static List<ExternalFileResponse> toListDto(List<UploadedFile> uploadedFiles) {
+        return uploadedFiles.stream()
+            .map(ExternalFileResponse::toDto)
+            .toList();
+    }
+}

--- a/src/main/java/com/saerok/showing/api/global/file/dto/FileUploadResponse.java
+++ b/src/main/java/com/saerok/showing/api/global/file/dto/FileUploadResponse.java
@@ -1,0 +1,33 @@
+package com.saerok.showing.api.global.file.dto;
+
+import com.saerok.showing.api.global.file.entity.UploadedFile;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FileUploadResponse {
+
+    private Long id;
+
+    private String originalFileName;
+
+    private String storedFileName;
+
+    private String fileUrl;
+
+    private Long fileSize;
+
+    private String contentType;
+
+    public static FileUploadResponse toDto(UploadedFile file) {
+        return FileUploadResponse.builder()
+            .id(file.getId())
+            .originalFileName(file.getOriginalFileName())
+            .storedFileName(file.getStoredFileName())
+            .fileUrl(file.getFileUrl())
+            .fileSize(file.getFileSize())
+            .contentType(file.getContentType())
+            .build();
+    }
+}

--- a/src/main/java/com/saerok/showing/api/global/file/dto/FileUploadResult.java
+++ b/src/main/java/com/saerok/showing/api/global/file/dto/FileUploadResult.java
@@ -1,0 +1,20 @@
+package com.saerok.showing.api.global.file.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FileUploadResult {
+
+    private String storedFileName;
+
+    private String fileUrl;
+
+    public static FileUploadResult create(String storedFileName, String fileUrl) {
+        return FileUploadResult.builder()
+            .storedFileName(storedFileName)
+            .fileUrl(fileUrl)
+            .build();
+    }
+}

--- a/src/main/java/com/saerok/showing/api/global/file/entity/UploadedFile.java
+++ b/src/main/java/com/saerok/showing/api/global/file/entity/UploadedFile.java
@@ -1,0 +1,57 @@
+package com.saerok.showing.api.global.file.entity;
+
+import com.saerok.showing.api.global.entity.BaseEntity;
+import com.saerok.showing.api.global.file.dto.FileUploadResult;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "uploaded_file")
+public class UploadedFile extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "uploaded_file_id")
+    private Long id;
+
+    @Column(name = "original_file_name", nullable = false)
+    private String originalFileName;
+
+    @Column(name = "stored_file_name", nullable = false, unique = true)
+    private String storedFileName;
+
+    @Column(name = "file_url", nullable = false)
+    private String fileUrl;
+
+    @Column(name = "file_size", nullable = false)
+    private Long fileSize;
+
+    @Column(name = "content_type")
+    private String contentType;
+
+    public static UploadedFile toEntity(FileUploadResult fileUploadResult, MultipartFile file) {
+        return UploadedFile.builder()
+            .originalFileName(file.getOriginalFilename())
+            .storedFileName(fileUploadResult.getStoredFileName())
+            .fileUrl(fileUploadResult.getFileUrl())
+            .fileSize(file.getSize())
+            .contentType(file.getContentType())
+            .build();
+    }
+}

--- a/src/main/java/com/saerok/showing/api/global/file/repository/FileRepository.java
+++ b/src/main/java/com/saerok/showing/api/global/file/repository/FileRepository.java
@@ -1,0 +1,15 @@
+package com.saerok.showing.api.global.file.repository;
+
+import com.saerok.showing.api.global.file.entity.UploadedFile;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FileRepository extends JpaRepository<UploadedFile, Long> {
+
+    Optional<UploadedFile> findByFileUrl(String fileUrl);
+
+    List<UploadedFile> findAllByFileUrlIn(List<String> fileUrls);
+}

--- a/src/main/java/com/saerok/showing/api/global/file/service/FileService.java
+++ b/src/main/java/com/saerok/showing/api/global/file/service/FileService.java
@@ -1,0 +1,51 @@
+package com.saerok.showing.api.global.file.service;
+
+import com.saerok.showing.api.global.exception.ErrorCode;
+import com.saerok.showing.api.global.exception.ShowingException;
+import com.saerok.showing.api.global.file.dto.FileUploadResponse;
+import com.saerok.showing.api.global.file.dto.FileUploadResult;
+import com.saerok.showing.api.global.file.entity.UploadedFile;
+import com.saerok.showing.api.global.file.repository.FileRepository;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class FileService {
+
+    private final StorageService storageService;
+    private final FileRepository fileRepository;
+
+    @Transactional
+    public List<FileUploadResponse> uploadFiles(List<MultipartFile> files, String folder) {
+        List<FileUploadResponse> fileUploadResponses = new ArrayList<>();
+        for (MultipartFile file : files) {
+            FileUploadResponse fileUploadResponse = uploadFile(file, folder);
+            fileUploadResponses.add(fileUploadResponse);
+        }
+        return fileUploadResponses;
+    }
+
+    @Transactional(readOnly = true)
+    public List<UploadedFile> getUploadedFilesByUrls(List<String> fileUrls) {
+        if (fileUrls == null || fileUrls.isEmpty()) {
+            return new ArrayList<>();
+        }
+        List<UploadedFile> uploadedFiles = fileRepository.findAllByFileUrlIn(fileUrls);
+        if (uploadedFiles.size() != fileUrls.size()) {
+            throw ShowingException.from(ErrorCode.INCLUDE_NOT_UPLOADED_FILE);
+        }
+        return uploadedFiles;
+    }
+
+    public FileUploadResponse uploadFile(MultipartFile file, String folder) {
+        FileUploadResult result = storageService.uploadFile(file, folder);
+        UploadedFile uploadedFile = UploadedFile.toEntity(result, file);
+        fileRepository.save(uploadedFile);
+        return FileUploadResponse.toDto(uploadedFile);
+    }
+}

--- a/src/main/java/com/saerok/showing/api/global/file/service/S3StorageService.java
+++ b/src/main/java/com/saerok/showing/api/global/file/service/S3StorageService.java
@@ -1,0 +1,94 @@
+package com.saerok.showing.api.global.file.service;
+
+import com.saerok.showing.api.global.exception.ErrorCode;
+import com.saerok.showing.api.global.exception.ShowingException;
+import com.saerok.showing.api.global.file.dto.FileUploadResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@Primary
+@RequiredArgsConstructor
+public class S3StorageService implements StorageService {
+
+    private final S3Client s3Client;
+
+    @Value("${BUCKET_NAME}")
+    private String bucketName;
+
+    @Value("${S3_REGION}")
+    private String region;
+
+    private static final List<String> ALLOWED_EXTENSIONS =
+        List.of(".jpg", ".jpeg", ".png", ".gif", ".pdf");
+
+    private static final long MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+
+    @Override
+    public FileUploadResult uploadFile(MultipartFile file, String folder) {
+        validateFileSize(file);
+        String originalFilename = file.getOriginalFilename();
+        String fileExtension = extractFileExtension(originalFilename);
+        validateExtension(fileExtension);
+
+        String storedFileName = checkFolder(folder) + UUID.randomUUID() + fileExtension;
+        return uploadS3(file, storedFileName, originalFilename);
+    }
+
+    private FileUploadResult uploadS3(MultipartFile file, String storedFileName, String originalFilename) {
+        PutObjectRequest request = PutObjectRequest.builder()
+            .bucket(bucketName)
+            .key(storedFileName)
+            .acl(ObjectCannedACL.BUCKET_OWNER_FULL_CONTROL)
+            .contentType(file.getContentType())
+            .contentDisposition("inline")
+            .build();
+
+        try {
+            s3Client.putObject(request, RequestBody.fromBytes(file.getBytes()));
+        } catch (IOException e) {
+            throw ShowingException.from(ErrorCode.S3_UPLOAD_FAILURE);
+        }
+
+        String fileUrl = String.format("https://%s.s3.%s.amazonaws.com/%s", bucketName, region, storedFileName);
+
+        return FileUploadResult.builder()
+            .storedFileName(storedFileName)
+            .fileUrl(fileUrl)
+            .build();
+    }
+
+    private String extractFileExtension(String originalFilename) {
+        if (originalFilename == null || !originalFilename.contains(".")) {
+            throw ShowingException.from(ErrorCode.UNSUPPORTED_FILE_EXTENSION);
+        }
+        return originalFilename.substring(originalFilename.lastIndexOf("."));
+    }
+
+    private void validateFileSize(MultipartFile file) {
+        if (file.getSize() > MAX_FILE_SIZE) {
+            throw ShowingException.from(ErrorCode.FILE_SIZE_EXCEEDED);
+        }
+    }
+
+    private void validateExtension(String extension) {
+        if (!ALLOWED_EXTENSIONS.contains(extension.toLowerCase())) {
+            throw ShowingException.from(ErrorCode.UNSUPPORTED_FILE_EXTENSION);
+        }
+    }
+
+    private String checkFolder(String folder) {
+        return folder.endsWith("/") ? folder : folder + "/";
+    }
+}

--- a/src/main/java/com/saerok/showing/api/global/file/service/StorageService.java
+++ b/src/main/java/com/saerok/showing/api/global/file/service/StorageService.java
@@ -1,0 +1,9 @@
+package com.saerok.showing.api.global.file.service;
+
+import com.saerok.showing.api.global.file.dto.FileUploadResult;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface StorageService {
+
+    FileUploadResult uploadFile(MultipartFile file, String folder);
+}

--- a/src/main/resources/application.yml.template
+++ b/src/main/resources/application.yml.template
@@ -76,6 +76,19 @@ spring:
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
 
+cloud:
+  aws:
+    s3:
+      bucket: ${BUCKET_NAME}
+    credentials:
+      access-key: ${S3_ACCESS_KEY}
+      secret-key: ${S3_SECRET_KEY}
+    region:
+      static: ${S3_REGION}
+      auto: false
+    stack:
+      auto: false
+
 cors:
   allowed-origins: ${CORS_ALLOWED_ORIGINS}
   allowed-methods: ${CORS_ALLOWED_METHODS}


### PR DESCRIPTION
## ⭐️ Overview

> #21

AWS S3 연동 및 도메인별 파일 업로드 기능을 구현했습니다.

## 🔧 Tasks

- AWS S3 세팅 및 연동
- 단일/다중 파일 업로드 로직 구현
- 업로드 전 파일 크기, 확장자, 이름 등에 대한 유효성 검증 로직 추가

## 📝 Additional Notes

- 파일 업로드는 도메인별로 S3에 저장되며, 응답으로 URL과 파일명이 반환됩니다.
- 허용 확장자: `.jpg`, `.jpeg`, `.png`, `.gif`, `.pdf`
- 최대 업로드 용량: 파일당 5MB
- 장소(테마, 숙소) 업로드는 관리자(`ADMIN`)만 접근 가능하도록 설정했습니다.
- 탐조 및 프로필 사진은 한 장만 업로드할 수 있습니다.
- 장소 및 리뷰 사진은 여러 장 업로드가 가능합니다.

## 📸 Screenshot

### 1. 파일 업로드 API 엔드포인트
<img width="370" alt="upload-endpoint" src="https://github.com/user-attachments/assets/36c229fe-f61e-43a7-a47c-70993c715b2b" />

### 2. 탐조 사진 업로드
<img width="970" alt="bird-upload" src="https://github.com/user-attachments/assets/e84a1769-f8c9-42d7-8d42-3e903dec2e02" />

### 3. 장소 사진 업로드 (THEME, PLACE)
<img width="970" alt="place-upload" src="https://github.com/user-attachments/assets/f53d8500-5cb2-4812-8c73-4aae485ca291" />

### 4. 리뷰 사진 업로드
<img width="970" alt="review-upload" src="https://github.com/user-attachments/assets/162f116a-9a04-4ffe-90d1-69147e93d571" />

### 5. 프로필 사진 업로드
<img width="970" alt="profile-upload" src="https://github.com/user-attachments/assets/add855e0-7160-4359-878f-e6a45bf06b9e" />