### PR TITLE
feat: Route 및 RoutePlace API 구현 완료

### DIFF
--- a/src/main/java/com/saerok/showing/api/domain/place/service/PlaceService.java
+++ b/src/main/java/com/saerok/showing/api/domain/place/service/PlaceService.java
@@ -51,7 +51,7 @@ public class PlaceService {
         );
     }
 
-    private Place findById(Long placeId) {
+    public Place findById(Long placeId) {
         return placeRepository.findById(placeId)
             .orElseThrow(() -> ShowingException.from(ErrorCode.PLACE_NOT_FOUND));
     }

--- a/src/main/java/com/saerok/showing/api/domain/review/service/ReviewService.java
+++ b/src/main/java/com/saerok/showing/api/domain/review/service/ReviewService.java
@@ -29,7 +29,7 @@ public class ReviewService {
         Member member = loginMemberProvider.getCurrentLoginMember();
         Review review = Review.toEntity(member, request);
         reviewRepository.save(review);
-        return null;
+        return review.getId();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/saerok/showing/api/domain/route/controller/RouteController.java
+++ b/src/main/java/com/saerok/showing/api/domain/route/controller/RouteController.java
@@ -1,16 +1,58 @@
 package com.saerok.showing.api.domain.route.controller;
 
+import com.saerok.showing.api.domain.route.dto.request.RouteCreateRequest;
 import com.saerok.showing.api.domain.route.service.RouteService;
+import com.saerok.showing.api.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/route")
 @RequiredArgsConstructor
-@Tag(name = "Route", description = "나만의 경로 관리")
+@Tag(name = "Route", description = "여행코스 생성/삭제")
 public class RouteController {
 
     private final RouteService routeService;
+
+    @Operation(
+        summary = "여행코스 생성",
+        description = """
+            [모든 Role 가능] 새로운 여행코스를 생성합니다.<br>
+            여행코스에는 제목, 여행 시작일자, 종료일자, 인원수가 필요합니다.<br>
+            코스 생성 시에는 장소가 포함되지 않으며, 이후 별도로 추가해야 합니다.
+            """
+    )
+    @PreAuthorize("hasRole('MEMBER')")
+    @PostMapping("")
+    public ApiResponse<Long> createRoute(
+        @Valid @RequestBody RouteCreateRequest routeCreateRequest
+    ) {
+        Long id = routeService.save(routeCreateRequest);
+        return ApiResponse.success(id);
+    }
+
+    @Operation(
+        summary = "여행코스 삭제",
+        description = """
+            [모든 Role 가능] 여행코스 ID를 기준으로 해당 코스를 삭제합니다.<br>
+            해당 여행코스 내 장소들도 함께 삭제됩니다.
+            """
+    )
+    @PreAuthorize("hasRole('MEMBER')")
+    @DeleteMapping("/{routeId}")
+    public ApiResponse<Long> deleteRoute(
+        @PathVariable(name = "routeId") Long routeId
+    ) {
+        Long id = routeService.delete(routeId);
+        return ApiResponse.success(id);
+    }
 }

--- a/src/main/java/com/saerok/showing/api/domain/route/dto/request/RouteCreateRequest.java
+++ b/src/main/java/com/saerok/showing/api/domain/route/dto/request/RouteCreateRequest.java
@@ -1,0 +1,28 @@
+package com.saerok.showing.api.domain.route.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class RouteCreateRequest {
+
+    @NotNull
+    @Schema(description = "내 여행코스 이름", example = "5학년 3반 나들이 여행코스")
+    private String title;
+
+    @NotNull
+    @Schema(description = "여행 시작일(yyyy-MM-dd)", example = "2025-05-21")
+    private LocalDate startDate;
+
+    @NotNull
+    @Schema(description = "여행 종료일(yyyy-MM-dd)", example = "2025-05-21")
+    private LocalDate endDate;
+
+    @NotNull
+    @Schema(description = "인원수", example = "2")
+    private int peopleCount;
+}

--- a/src/main/java/com/saerok/showing/api/domain/route/dto/request/RouteCreateRequest.java
+++ b/src/main/java/com/saerok/showing/api/domain/route/dto/request/RouteCreateRequest.java
@@ -1,6 +1,8 @@
 package com.saerok.showing.api.domain.route.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import lombok.Getter;
@@ -15,14 +17,16 @@ public class RouteCreateRequest {
     private String title;
 
     @NotNull
-    @Schema(description = "여행 시작일(yyyy-MM-dd)", example = "2025-05-21")
+    @Schema(description = "여행 시작일(yyyy-MM-dd)", example = "2025-07-08")
     private LocalDate startDate;
 
     @NotNull
-    @Schema(description = "여행 종료일(yyyy-MM-dd)", example = "2025-05-21")
+    @Schema(description = "여행 종료일(yyyy-MM-dd)", example = "2025-07-08")
     private LocalDate endDate;
 
+    @Min(1)
+    @Max(100)
     @NotNull
-    @Schema(description = "인원수", example = "2")
+    @Schema(description = "인원수, 1~100의 값을 가질 수 있습니다.", example = "15")
     private int peopleCount;
 }

--- a/src/main/java/com/saerok/showing/api/domain/route/entity/Route.java
+++ b/src/main/java/com/saerok/showing/api/domain/route/entity/Route.java
@@ -1,8 +1,12 @@
 package com.saerok.showing.api.domain.route.entity;
 
 import com.saerok.showing.api.domain.member.entity.Member;
-import com.saerok.showing.api.domain.place.entity.Place;
+import com.saerok.showing.api.domain.route.dto.request.RouteCreateRequest;
+import com.saerok.showing.api.domain.routePlace.entity.RoutePlace;
 import com.saerok.showing.api.global.entity.BaseEntity;
+import com.saerok.showing.api.global.exception.ErrorCode;
+import com.saerok.showing.api.global.exception.ShowingException;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -11,8 +15,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -38,10 +45,6 @@ public class Route extends BaseEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "place_id", nullable = false)
-    private Place place;
-
     @Column(name = "title", nullable = false)
     private String title;
 
@@ -53,4 +56,23 @@ public class Route extends BaseEntity {
 
     @Column(name = "people_count")
     private Integer peopleCount;
+
+    @OneToMany(mappedBy = "route", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<RoutePlace> routePlaces = new ArrayList<>();
+
+    public static Route toEntity(Member member, RouteCreateRequest request) {
+        return Route.builder()
+            .member(member)
+            .title(request.getTitle())
+            .startDate(request.getStartDate())
+            .endDate(request.getEndDate())
+            .peopleCount(request.getPeopleCount())
+            .build();
+    }
+
+    public void validateOwner(Member member) {
+        if (!this.member.getId().equals(member.getId())) {
+            throw ShowingException.from(ErrorCode.ROUTE_MAKER_MISMATCH);
+        }
+    }
 }

--- a/src/main/java/com/saerok/showing/api/domain/route/service/RouteService.java
+++ b/src/main/java/com/saerok/showing/api/domain/route/service/RouteService.java
@@ -1,12 +1,41 @@
 package com.saerok.showing.api.domain.route.service;
 
+import com.saerok.showing.api.domain.member.entity.Member;
+import com.saerok.showing.api.domain.route.dto.request.RouteCreateRequest;
+import com.saerok.showing.api.domain.route.entity.Route;
 import com.saerok.showing.api.domain.route.repository.RouteRepository;
+import com.saerok.showing.api.global.auth.util.LoginMemberProvider;
+import com.saerok.showing.api.global.exception.ErrorCode;
+import com.saerok.showing.api.global.exception.ShowingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class RouteService {
 
     private final RouteRepository routeRepository;
+    private final LoginMemberProvider loginMemberProvider;
+
+    @Transactional
+    public Long save(RouteCreateRequest request) {
+        Member member = loginMemberProvider.getCurrentLoginMember();
+        Route route = Route.toEntity(member, request);
+        return routeRepository.save(route).getId();
+    }
+
+    @Transactional
+    public Long delete(Long routeId) {
+        Member currentMember = loginMemberProvider.getCurrentLoginMember();
+        Route route = findById(routeId);
+        route.validateOwner(currentMember);
+        routeRepository.deleteById(routeId);
+        return routeId;
+    }
+
+    public Route findById(Long routeId) {
+        return routeRepository.findById(routeId)
+            .orElseThrow(() -> ShowingException.from(ErrorCode.ROUTE_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/saerok/showing/api/domain/routePlace/controller/RoutePlaceController.java
+++ b/src/main/java/com/saerok/showing/api/domain/routePlace/controller/RoutePlaceController.java
@@ -1,0 +1,97 @@
+package com.saerok.showing.api.domain.routePlace.controller;
+
+import com.saerok.showing.api.domain.routePlace.dto.request.RoutePlaceCreateRequest;
+import com.saerok.showing.api.domain.routePlace.dto.request.RoutePlaceUpdateRequest;
+import com.saerok.showing.api.domain.routePlace.dto.response.RoutePlaceListResponse;
+import com.saerok.showing.api.domain.routePlace.service.RoutePlaceService;
+import com.saerok.showing.api.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/route")
+@RequiredArgsConstructor
+@Tag(name = "RoutePlace", description = "여행코스 내부 장소 관리")
+public class RoutePlaceController {
+
+    private final RoutePlaceService routePlaceService;
+
+    @Operation(
+        summary = "여행코스 내 장소 추가",
+        description = """
+            [모든 Role 가능] 여행코스에 장소를 추가합니다.<br>
+            장소는 방문 일자(dayNumber)와 해당 일자 내 방문 순서(orderInDay)를 함께 지정해야 합니다.
+            """
+    )
+    @PreAuthorize("hasRole('MEMBER')")
+    @PostMapping("/{routeId}/places")
+    public ApiResponse<Long> addRoutePlace(
+        @PathVariable Long routeId,
+        @Valid @RequestBody RoutePlaceCreateRequest request
+    ) {
+        Long createdId = routePlaceService.addRoutePlace(routeId, request);
+        return ApiResponse.success(createdId);
+    }
+
+    @Operation(
+        summary = "여행코스 일차별 장소 목록 조회",
+        description = """
+            [모든 Role 가능] 여행코스 내에 등록된 장소들을 일차(dayNumber)와 방문 순서(orderInDay)에 따라 정렬하여 조회합니다.<br>
+            반환 데이터는 일차별로 그룹화되어 있습니다.
+            """
+    )
+    @PreAuthorize("hasRole('MEMBER')")
+    @GetMapping("/{routeId}/places")
+    public ApiResponse<RoutePlaceListResponse> getRoutePlaces(
+        @PathVariable Long routeId
+    ) {
+        RoutePlaceListResponse response = routePlaceService.getRoutePlaces(routeId);
+        return ApiResponse.success(response);
+    }
+
+    @Operation(
+        summary = "여행코스 내 장소 수정",
+        description = """
+            [모든 Role 가능] 여행코스 내 특정 장소의 방문 일자(dayNumber) 또는 해당 일자 내 방문 순서(orderInDay)를 수정합니다.<br>
+            route ID와 routePlace ID 모두 필요합니다.
+            """
+    )
+    @PreAuthorize("hasRole('MEMBER')")
+    @PatchMapping("/{routeId}/places/{routePlaceId}")
+    public ApiResponse<Long> updateRoutePlace(
+        @PathVariable Long routeId,
+        @PathVariable Long routePlaceId,
+        @Valid @RequestBody RoutePlaceUpdateRequest request
+    ) {
+        Long updatedId = routePlaceService.updateRoutePlace(routeId, routePlaceId, request);
+        return ApiResponse.success(updatedId);
+    }
+
+    @Operation(
+        summary = "여행코스 내 장소 삭제",
+        description = """
+            [모든 Role 가능] 특정 여행코스에서 지정한 장소(routePlace)를 삭제합니다.<br>
+            장소를 삭제하면 해당 일차의 나머지 순서에는 영향을 주지 않습니다.
+            """
+    )
+    @PreAuthorize("hasRole('MEMBER')")
+    @DeleteMapping("/{routeId}/places/{routePlaceId}")
+    public ApiResponse<Long> deleteRoutePlace(
+        @PathVariable Long routeId,
+        @PathVariable Long routePlaceId
+    ) {
+        Long deletedId = routePlaceService.deleteRoutePlace(routeId, routePlaceId);
+        return ApiResponse.success(deletedId);
+    }
+}

--- a/src/main/java/com/saerok/showing/api/domain/routePlace/dto/request/RoutePlaceCreateRequest.java
+++ b/src/main/java/com/saerok/showing/api/domain/routePlace/dto/request/RoutePlaceCreateRequest.java
@@ -1,0 +1,29 @@
+package com.saerok.showing.api.domain.routePlace.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class RoutePlaceCreateRequest {
+
+    @NotNull
+    @Schema(description = "추가할 장소의 ID", example = "1")
+    private Long placeId;
+
+    @Min(1)
+    @Max(30)
+    @NotNull
+    @Schema(description = "여행 경로에서 해당 장소를 방문할 일자(Day N)입니다, N은 1~30의 값입니다.", example = "1")
+    private int dayNumber;
+
+    @Min(1)
+    @Max(30)
+    @NotNull
+    @Schema(description = "해당 일자 내 장소 방문 순서(M번쨰)입니다. M은 1~30의 값입니다.", example = "1")
+    private int orderInDay;
+}

--- a/src/main/java/com/saerok/showing/api/domain/routePlace/dto/request/RoutePlaceUpdateRequest.java
+++ b/src/main/java/com/saerok/showing/api/domain/routePlace/dto/request/RoutePlaceUpdateRequest.java
@@ -1,0 +1,25 @@
+package com.saerok.showing.api.domain.routePlace.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class RoutePlaceUpdateRequest {
+
+    @Min(1)
+    @Max(30)
+    @NotNull
+    @Schema(description = "여행 경로에서 해당 장소의 방문 일자(Day N)를 수정합니다, N은 1~30의 값입니다.", example = "1")
+    private int dayNumber;
+
+    @Min(1)
+    @Max(30)
+    @NotNull
+    @Schema(description = "해당 일자 내에서 장소 방문 순서를 수정합니다. 1~30의 값을 가집니다.", example = "1")
+    private int orderInDay;
+}

--- a/src/main/java/com/saerok/showing/api/domain/routePlace/dto/response/DayGroupResponse.java
+++ b/src/main/java/com/saerok/showing/api/domain/routePlace/dto/response/DayGroupResponse.java
@@ -1,0 +1,17 @@
+package com.saerok.showing.api.domain.routePlace.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DayGroupResponse {
+
+    private int dayNumber;
+
+    private LocalDate visitDate;
+
+    private List<RoutePlaceBoxResponse> places;
+}

--- a/src/main/java/com/saerok/showing/api/domain/routePlace/dto/response/RoutePlaceBoxResponse.java
+++ b/src/main/java/com/saerok/showing/api/domain/routePlace/dto/response/RoutePlaceBoxResponse.java
@@ -1,0 +1,30 @@
+package com.saerok.showing.api.domain.routePlace.dto.response;
+
+import com.saerok.showing.api.domain.routePlace.entity.RoutePlace;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RoutePlaceBoxResponse {
+
+    private Long id;
+
+    private String title;
+
+    private int dayNumber;
+
+    private int orderInDay;
+
+    private String imageUrl;
+
+    public static RoutePlaceBoxResponse toDto(RoutePlace routePlace) {
+        return RoutePlaceBoxResponse.builder()
+            .id(routePlace.getId())
+            .title(routePlace.getPlace().getTitle())
+            .dayNumber(routePlace.getDayNumber())
+            .orderInDay(routePlace.getOrderInDay())
+            .imageUrl(routePlace.getPlace().getPlaceImage())
+            .build();
+    }
+}

--- a/src/main/java/com/saerok/showing/api/domain/routePlace/dto/response/RoutePlaceListResponse.java
+++ b/src/main/java/com/saerok/showing/api/domain/routePlace/dto/response/RoutePlaceListResponse.java
@@ -17,20 +17,20 @@ public class RoutePlaceListResponse {
     private List<DayGroupResponse> days;
 
     public static RoutePlaceListResponse toDto(Route route, List<RoutePlace> routePlaces) {
-        // 1. dayNumber 기준으로 RoutePlace들을 그룹핑
+        // dayNumber 기준 그룹핑 (순서 유지)
         Map<Integer, List<RoutePlace>> grouped = routePlaces.stream()
             .collect(Collectors.groupingBy(
                 RoutePlace::getDayNumber,
-                LinkedHashMap::new, // 순서유지
+                LinkedHashMap::new,
                 Collectors.toList()
             ));
-        // 2. 그룹핑된 데이터를 DayGroupResponse 형태로 변환
+        // 그룹 데이터를 DayGroupResponse 리스트로 변환
         List<DayGroupResponse> days = grouped.entrySet().stream()
             .map(entry -> {
                 int day = entry.getKey();
                 LocalDate visitDate = route.getStartDate().plusDays(day - 1);
-                List<RoutePlaceSummaryResponse> summaries = entry.getValue().stream()
-                    .map(RoutePlaceSummaryResponse::toDto)
+                List<RoutePlaceBoxResponse> summaries = entry.getValue().stream()
+                    .map(RoutePlaceBoxResponse::toDto)
                     .toList();
                 return new DayGroupResponse(day, visitDate, summaries);
             })

--- a/src/main/java/com/saerok/showing/api/domain/routePlace/dto/response/RoutePlaceListResponse.java
+++ b/src/main/java/com/saerok/showing/api/domain/routePlace/dto/response/RoutePlaceListResponse.java
@@ -1,0 +1,41 @@
+package com.saerok.showing.api.domain.routePlace.dto.response;
+
+import com.saerok.showing.api.domain.route.entity.Route;
+import com.saerok.showing.api.domain.routePlace.entity.RoutePlace;
+import java.time.LocalDate;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RoutePlaceListResponse {
+
+    private List<DayGroupResponse> days;
+
+    public static RoutePlaceListResponse toDto(Route route, List<RoutePlace> routePlaces) {
+        // 1. dayNumber 기준으로 RoutePlace들을 그룹핑
+        Map<Integer, List<RoutePlace>> grouped = routePlaces.stream()
+            .collect(Collectors.groupingBy(
+                RoutePlace::getDayNumber,
+                LinkedHashMap::new, // 순서유지
+                Collectors.toList()
+            ));
+        // 2. 그룹핑된 데이터를 DayGroupResponse 형태로 변환
+        List<DayGroupResponse> days = grouped.entrySet().stream()
+            .map(entry -> {
+                int day = entry.getKey();
+                LocalDate visitDate = route.getStartDate().plusDays(day - 1);
+                List<RoutePlaceSummaryResponse> summaries = entry.getValue().stream()
+                    .map(RoutePlaceSummaryResponse::toDto)
+                    .toList();
+                return new DayGroupResponse(day, visitDate, summaries);
+            })
+            .toList();
+
+        return RoutePlaceListResponse.builder().days(days).build();
+    }
+}

--- a/src/main/java/com/saerok/showing/api/domain/routePlace/entity/RoutePlace.java
+++ b/src/main/java/com/saerok/showing/api/domain/routePlace/entity/RoutePlace.java
@@ -1,0 +1,73 @@
+package com.saerok.showing.api.domain.routePlace.entity;
+
+import com.saerok.showing.api.domain.place.entity.Place;
+import com.saerok.showing.api.domain.route.entity.Route;
+import com.saerok.showing.api.domain.routePlace.dto.request.RoutePlaceCreateRequest;
+import com.saerok.showing.api.domain.routePlace.dto.request.RoutePlaceUpdateRequest;
+import com.saerok.showing.api.global.entity.BaseEntity;
+import com.saerok.showing.api.global.exception.ErrorCode;
+import com.saerok.showing.api.global.exception.ShowingException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "route_place")
+public class RoutePlace extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "route_place_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "route_id", nullable = false)
+    private Route route;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "place_id", nullable = false)
+    private Place place;
+
+    @Column(name = "day_number", nullable = false)
+    private int dayNumber;
+
+    @Column(name = "order_in_day", nullable = false)
+    private int orderInDay;
+
+    public static RoutePlace toEntity(RoutePlaceCreateRequest request, Route route, Place place) {
+        return RoutePlace.builder()
+            .route(route)
+            .place(place)
+            .dayNumber(request.getDayNumber())
+            .orderInDay(request.getOrderInDay())
+            .build();
+    }
+
+    public void update(RoutePlaceUpdateRequest request) {
+        this.dayNumber = request.getDayNumber();
+        this.orderInDay = request.getOrderInDay();
+    }
+
+    public void validateBelongsTo(Route route) {
+        if (!this.route.getId().equals(route.getId())) {
+            throw ShowingException.from(ErrorCode.ROUTE_MAKER_MISMATCH);
+        }
+    }
+}

--- a/src/main/java/com/saerok/showing/api/domain/routePlace/repository/RoutePlaceRepository.java
+++ b/src/main/java/com/saerok/showing/api/domain/routePlace/repository/RoutePlaceRepository.java
@@ -4,10 +4,24 @@ import com.saerok.showing.api.domain.route.entity.Route;
 import com.saerok.showing.api.domain.routePlace.entity.RoutePlace;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RoutePlaceRepository extends JpaRepository<RoutePlace, Long> {
 
     List<RoutePlace> findByRouteOrderByDayNumberAscOrderInDayAsc(Route route);
+
+    @Modifying
+    @Query("""
+            UPDATE RoutePlace rp
+            SET rp.orderInDay = rp.orderInDay + 1
+            WHERE rp.route.id = :routeId
+              AND rp.dayNumber = :dayNumber
+              AND rp.orderInDay >= :startOrder
+        """)
+    void shiftOrdersForward(Long routeId, int dayNumber, int startOrder);
+
+    boolean existsByRouteIdAndDayNumberAndOrderInDay(Long routeId, int dayNumber, int orderInDay);
 }

--- a/src/main/java/com/saerok/showing/api/domain/routePlace/repository/RoutePlaceRepository.java
+++ b/src/main/java/com/saerok/showing/api/domain/routePlace/repository/RoutePlaceRepository.java
@@ -1,0 +1,13 @@
+package com.saerok.showing.api.domain.routePlace.repository;
+
+import com.saerok.showing.api.domain.route.entity.Route;
+import com.saerok.showing.api.domain.routePlace.entity.RoutePlace;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RoutePlaceRepository extends JpaRepository<RoutePlace, Long> {
+
+    List<RoutePlace> findByRouteOrderByDayNumberAscOrderInDayAsc(Route route);
+}

--- a/src/main/java/com/saerok/showing/api/domain/routePlace/service/RoutePlaceService.java
+++ b/src/main/java/com/saerok/showing/api/domain/routePlace/service/RoutePlaceService.java
@@ -32,6 +32,7 @@ public class RoutePlaceService {
         Member currentMember = loginMemberProvider.getCurrentLoginMember();
         Route route = findRouteWithOwnerValidation(routeId, currentMember);
         Place place = placeService.findById(request.getPlaceId());
+        shiftOrderIfDuplicate(routeId, request.getDayNumber(), request.getOrderInDay());
         RoutePlace routePlace = RoutePlace.toEntity(request, route, place);
         routePlaceRepository.save(routePlace);
         return routePlace.getId();
@@ -50,6 +51,9 @@ public class RoutePlaceService {
         Member currentMember = loginMemberProvider.getCurrentLoginMember();
         Route route = findRouteWithOwnerValidation(routeId, currentMember);
         RoutePlace routePlace = findById(routePlaceId);
+        if (isUpdateRequired(routePlace, request)) {
+            shiftOrderIfDuplicate(routeId, request.getDayNumber(), request.getOrderInDay());
+        }
         routePlace.validateBelongsTo(route);
         routePlace.update(request);
         return routePlace.getId();
@@ -68,6 +72,18 @@ public class RoutePlaceService {
     @Transactional(readOnly = true)
     public List<RoutePlace> findByRouteOrderByDayNumberAscOrderInDayAsc(Route route) {
         return routePlaceRepository.findByRouteOrderByDayNumberAscOrderInDayAsc(route);
+    }
+
+    private void shiftOrderIfDuplicate(Long routeId, int dayNumber, int orderInDay) {
+        boolean exists = routePlaceRepository.existsByRouteIdAndDayNumberAndOrderInDay(routeId, dayNumber, orderInDay);
+        if (exists) {
+            routePlaceRepository.shiftOrdersForward(routeId, dayNumber, orderInDay);
+        }
+    }
+
+    private boolean isUpdateRequired(RoutePlace routePlace, RoutePlaceUpdateRequest request) {
+        return routePlace.getDayNumber() != request.getDayNumber() ||
+            routePlace.getOrderInDay() != request.getOrderInDay();
     }
 
     private Route findRouteWithOwnerValidation(Long routeId, Member currentMember) {

--- a/src/main/java/com/saerok/showing/api/domain/routePlace/service/RoutePlaceService.java
+++ b/src/main/java/com/saerok/showing/api/domain/routePlace/service/RoutePlaceService.java
@@ -1,0 +1,83 @@
+package com.saerok.showing.api.domain.routePlace.service;
+
+import com.saerok.showing.api.domain.member.entity.Member;
+import com.saerok.showing.api.domain.place.entity.Place;
+import com.saerok.showing.api.domain.place.service.PlaceService;
+import com.saerok.showing.api.domain.route.entity.Route;
+import com.saerok.showing.api.domain.route.service.RouteService;
+import com.saerok.showing.api.domain.routePlace.dto.request.RoutePlaceCreateRequest;
+import com.saerok.showing.api.domain.routePlace.dto.request.RoutePlaceUpdateRequest;
+import com.saerok.showing.api.domain.routePlace.dto.response.RoutePlaceListResponse;
+import com.saerok.showing.api.domain.routePlace.entity.RoutePlace;
+import com.saerok.showing.api.domain.routePlace.repository.RoutePlaceRepository;
+import com.saerok.showing.api.global.auth.util.LoginMemberProvider;
+import com.saerok.showing.api.global.exception.ErrorCode;
+import com.saerok.showing.api.global.exception.ShowingException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RoutePlaceService {
+
+    private final RoutePlaceRepository routePlaceRepository;
+    private final RouteService routeService;
+    private final PlaceService placeService;
+    private final LoginMemberProvider loginMemberProvider;
+
+    @Transactional
+    public Long addRoutePlace(Long routeId, RoutePlaceCreateRequest request) {
+        Member currentMember = loginMemberProvider.getCurrentLoginMember();
+        Route route = findRouteWithOwnerValidation(routeId, currentMember);
+        Place place = placeService.findById(request.getPlaceId());
+        RoutePlace routePlace = RoutePlace.toEntity(request, route, place);
+        routePlaceRepository.save(routePlace);
+        return routePlace.getId();
+    }
+
+    @Transactional(readOnly = true)
+    public RoutePlaceListResponse getRoutePlaces(Long routeId) {
+        Member currentMember = loginMemberProvider.getCurrentLoginMember();
+        Route route = findRouteWithOwnerValidation(routeId, currentMember);
+        List<RoutePlace> places = findByRouteOrderByDayNumberAscOrderInDayAsc(route);
+        return RoutePlaceListResponse.toDto(route, places);
+    }
+
+    @Transactional
+    public Long updateRoutePlace(Long routeId, Long routePlaceId, RoutePlaceUpdateRequest request) {
+        Member currentMember = loginMemberProvider.getCurrentLoginMember();
+        Route route = findRouteWithOwnerValidation(routeId, currentMember);
+        RoutePlace routePlace = findById(routePlaceId);
+        routePlace.validateBelongsTo(route);
+        routePlace.update(request);
+        return routePlace.getId();
+    }
+
+    @Transactional
+    public Long deleteRoutePlace(Long routeId, Long routePlaceId) {
+        Member currentMember = loginMemberProvider.getCurrentLoginMember();
+        Route route = findRouteWithOwnerValidation(routeId, currentMember);
+        RoutePlace routePlace = findById(routePlaceId);
+        routePlace.validateBelongsTo(route);
+        routePlaceRepository.delete(routePlace);
+        return routePlaceId;
+    }
+
+    @Transactional(readOnly = true)
+    public List<RoutePlace> findByRouteOrderByDayNumberAscOrderInDayAsc(Route route) {
+        return routePlaceRepository.findByRouteOrderByDayNumberAscOrderInDayAsc(route);
+    }
+
+    private Route findRouteWithOwnerValidation(Long routeId, Member currentMember) {
+        Route route = routeService.findById(routeId);
+        route.validateOwner(currentMember);
+        return route;
+    }
+
+    private RoutePlace findById(Long routePlaceId) {
+        return routePlaceRepository.findById(routePlaceId)
+            .orElseThrow(() -> ShowingException.from(ErrorCode.ROUTE_PLACE_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/saerok/showing/api/global/exception/ErrorCode.java
+++ b/src/main/java/com/saerok/showing/api/global/exception/ErrorCode.java
@@ -31,7 +31,8 @@ public enum ErrorCode {
     // 403: FORBIDDEN (권한 없음)
     FORBIDDEN(HttpStatus.FORBIDDEN, "접근이 거부되었습니다."),
     MEMBER_NOT_ADMIN(HttpStatus.FORBIDDEN, "관리자 권한이 필요합니다."),
-    REVIEW_WRITER_MISMATCH(HttpStatus.FORBIDDEN, "리뷰 작성자가 아닙니다."),
+    REVIEW_WRITER_MISMATCH(HttpStatus.FORBIDDEN, "요청한 리뷰에 대해 접근 권한이 아닙니다."),
+    ROUTE_MAKER_MISMATCH(HttpStatus.FORBIDDEN, "요청한 여행코스에 대해 접근 권한이 없습니다."),
 
     // 404: NOT FOUND (리소스를 찾을 수 없음)
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다."),
@@ -40,6 +41,8 @@ public enum ErrorCode {
     BIRD_NOT_FOUND(HttpStatus.NOT_FOUND, "새를 찾을 수 없습니다."),
     PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "장소를 찾을 수 없습니다."),
     REVIEW_TARGET_NOT_FOUND(HttpStatus.NOT_FOUND, "리뷰를 찾을 수 없습니다."),
+    ROUTE_NOT_FOUND(HttpStatus.NOT_FOUND, "나만의 경로를 찾을 수 없습니다."),
+    ROUTE_PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "여행코스 내 장소를 찾을 수 없습니다."),
     PROFILE_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "프로필 이미지를 찾을 수 없습니다."),
     TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "토큰을 찾을 수 없습니다."),
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "리뷰를 찾을 수 없습니다."),

--- a/src/main/resources/application.yml.template
+++ b/src/main/resources/application.yml.template
@@ -16,7 +16,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
       dialect: org.hibernate.dialect.PostgreSQLDialect
     properties:
       hibernate.jdbc.time_zone: Asia/Seoul

--- a/src/main/resources/application.yml.template
+++ b/src/main/resources/application.yml.template
@@ -16,7 +16,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
       dialect: org.hibernate.dialect.PostgreSQLDialect
     properties:
       hibernate.jdbc.time_zone: Asia/Seoul


### PR DESCRIPTION
## ⭐️ Overview

> #14

여행코스 API를 구현했습니다.

## 🔧 Tasks

- 여행코스 생성 API 구현
- 여행코스 삭제 API 구현
- 여행코스 내 장소 추가 API 구현
- 여행코스 내 장소 조회 API 구현
- 여행코스 내 장소 수정 API 구현
- 여행코스 내 장소 삭제 API 구현

## 📝 Additional Notes

- 장소 추가 및 수정 시, 동일한 날짜의 중복 순서가 존재하면 시프트 로직으로 순서를 자동 조정합니다.
- 여행코스 조회는 다른 그룹 사용자에게도 공개되며, 수정 및 삭제는 생성자만 수행할 수 있습니다.

## 📸 Screenshot

### 여행코스 API
<img src="https://github.com/user-attachments/assets/67b29dad-a32a-4d9d-b41e-0ec98ed688d9" width="600"/>

### 여행코스 생성
<img src="https://github.com/user-attachments/assets/bfd49dd6-c5af-4cdc-82af-61a48392eaf9" width="600"/>

### 여행코스 삭제
<img src="https://github.com/user-attachments/assets/3ab22374-f25f-4a35-a4ef-ba424efdb0c1" width="600"/>

### 여행코스 내 장소 추가
<img src="https://github.com/user-attachments/assets/69465b5d-1eb2-44b2-9eff-ed7d99bfd026" width="600"/>

### 여행코스 내 장소 조회
<img src="https://github.com/user-attachments/assets/0d626dab-cb70-4aa1-bd39-a0bcd00be171" width="600"/>

### 여행코스 내 장소 수정
<img src="https://github.com/user-attachments/assets/da70947f-945b-4062-ae7a-fb3ba7e0d508" width="600"/>

### 여행코스 내 장소 삭제
<img src="https://github.com/user-attachments/assets/4a366aaa-339e-4d81-b6de-99629dc8f303" width="600"/>