### PR TITLE
feat: Team API 구현 완료

### DIFF
--- a/src/main/java/com/saerok/showing/api/domain/member/entity/Member.java
+++ b/src/main/java/com/saerok/showing/api/domain/member/entity/Member.java
@@ -1,14 +1,18 @@
 package com.saerok.showing.api.domain.member.entity;
 
 import com.saerok.showing.api.domain.member.dto.request.MemberUpdateRequest;
+import com.saerok.showing.api.domain.team.entity.Team;
 import com.saerok.showing.api.global.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.util.Optional;
 import lombok.AccessLevel;
@@ -52,8 +56,20 @@ public class Member extends BaseEntity {
     @Column(name = "login_type")
     private LoginType loginType;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id")
+    private Team team;
+
     public void update(MemberUpdateRequest memberUpdateRequest) {
         Optional.ofNullable(memberUpdateRequest.getName()).ifPresent(this::setName);
         Optional.ofNullable(memberUpdateRequest.getProfileImage()).ifPresent(this::setProfileImage);
+    }
+
+    public void joinTeam(Team team) {
+        this.team = team;
+    }
+
+    public void leaveTeam() {
+        this.team = null;
     }
 }

--- a/src/main/java/com/saerok/showing/api/domain/route/controller/RouteController.java
+++ b/src/main/java/com/saerok/showing/api/domain/route/controller/RouteController.java
@@ -34,9 +34,9 @@ public class RouteController {
     @PreAuthorize("hasRole('MEMBER')")
     @PostMapping("")
     public ApiResponse<Long> createRoute(
-        @Valid @RequestBody RouteCreateRequest routeCreateRequest
+        @Valid @RequestBody RouteCreateRequest request
     ) {
-        Long id = routeService.save(routeCreateRequest);
+        Long id = routeService.save(request);
         return ApiResponse.success(id);
     }
 

--- a/src/main/java/com/saerok/showing/api/domain/team/controller/TeamController.java
+++ b/src/main/java/com/saerok/showing/api/domain/team/controller/TeamController.java
@@ -1,0 +1,108 @@
+package com.saerok.showing.api.domain.team.controller;
+
+import com.saerok.showing.api.domain.team.dto.request.TeamCreateRequest;
+import com.saerok.showing.api.domain.team.dto.response.TeamMemberResponse;
+import com.saerok.showing.api.domain.team.service.TeamService;
+import com.saerok.showing.api.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/team")
+@RequiredArgsConstructor
+@Tag(name = "Team", description = "팀 생성/삭제")
+public class TeamController {
+
+    private final TeamService teamService;
+
+    @Operation(
+        summary = "팀 생성",
+        description = """
+            [모든 Role 가능] 새로운 팀을 생성합니다.<br>
+            팀을 생성한 사람은 팀리더가 됩니다.<br>
+            이미 팀이 존재하는 회원은 팀 생성을 할 수 없습니다.
+            """
+    )
+    @PreAuthorize("hasRole('MEMBER')")
+    @PostMapping("")
+    public ApiResponse<Long> createTeam(
+        @Valid @RequestBody TeamCreateRequest request
+    ) {
+        Long id = teamService.save(request);
+        return ApiResponse.success(id);
+    }
+
+    @Operation(
+        summary = "팀 가입",
+        description = """
+            [모든 Role 가능] 팀에 가입합니다.<br>
+            이미 팀이 존재하거나 요청한 팀에 가입된 경우는 가입되지 않습니다.
+            """
+    )
+    @PreAuthorize("hasRole('MEMBER')")
+    @PostMapping("/{teamId}/join")
+    public ApiResponse<Long> joinTeam(
+        @PathVariable(name = "teamId") Long teamId
+    ) {
+        Long id = teamService.joinTeam(teamId);
+        return ApiResponse.success(id);
+    }
+
+    @Operation(
+        summary = "팀 탈퇴",
+        description = """
+            [모든 Role 가능] 현재 로그인한 사용자가 팀에서 탈퇴합니다.<br>
+            팀의 소속인 회원만 탈퇴할 수 있습니다.<br>
+            팀의 리더가 탈퇴하는 경우, 해당 팀이 사라집니다.
+            """
+    )
+    @PreAuthorize("hasRole('MEMBER')")
+    @PostMapping("/{teamId}/leave")
+    public ApiResponse<Long> leaveTeam(
+        @PathVariable(name = "teamId") Long teamId
+    ) {
+        Long id = teamService.leaveTeam(teamId);
+        return ApiResponse.success(id);
+    }
+
+    @Operation(
+        summary = "팀 내 팀원 목록 조회",
+        description = """
+            [모든 Role 가능] 팀에 속한 팀원들을 조회합니다.<br>
+            먼저 가입한 순으로 정렬되며, 팀리더가 제일먼저입니다.
+            """
+    )
+    @PreAuthorize("hasRole('MEMBER')")
+    @GetMapping("/members")
+    public ApiResponse<List<TeamMemberResponse>> getMyTeamMembers() {
+        List<TeamMemberResponse> members = teamService.getMyTeamMembers();
+        return ApiResponse.success(members);
+    }
+
+    @Operation(
+        summary = "팀 삭제",
+        description = """
+            [모든 Role 가능] 팀을 삭제합니다.<br>
+            팀이 삭제되면, 팀에 속한 팀리더와 팀원들의 소속이 사라집니다.
+            """
+    )
+    @PreAuthorize("hasRole('MEMBER')")
+    @DeleteMapping("/{teamId}")
+    public ApiResponse<Long> deleteTeam(
+        @PathVariable(name = "teamId") Long teamId
+    ) {
+        Long id = teamService.delete(teamId);
+        return ApiResponse.success(id);
+    }
+}

--- a/src/main/java/com/saerok/showing/api/domain/team/dto/request/TeamCreateRequest.java
+++ b/src/main/java/com/saerok/showing/api/domain/team/dto/request/TeamCreateRequest.java
@@ -1,0 +1,17 @@
+package com.saerok.showing.api.domain.team.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TeamCreateRequest {
+
+    @NotNull
+    @Size(min = 2, max = 30)
+    @Schema(description = "팀(그룹, 소속, 학교, 단체) 이름을 입력합니다, 팀 이름은 2 ~ 30글자 입니다.", example = "금화초등학교")
+    private String name;
+}

--- a/src/main/java/com/saerok/showing/api/domain/team/dto/response/TeamMemberResponse.java
+++ b/src/main/java/com/saerok/showing/api/domain/team/dto/response/TeamMemberResponse.java
@@ -1,0 +1,27 @@
+package com.saerok.showing.api.domain.team.dto.response;
+
+import com.saerok.showing.api.domain.member.entity.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TeamMemberResponse {
+
+    private Long teamId;
+
+    private Long memberId;
+
+    private String name;
+
+    private String profileImage;
+
+    public static TeamMemberResponse toDto(Member member) {
+        return TeamMemberResponse.builder()
+            .teamId(member.getTeam().getId())
+            .memberId(member.getId())
+            .name(member.getName())
+            .profileImage(member.getProfileImage())
+            .build();
+    }
+}

--- a/src/main/java/com/saerok/showing/api/domain/team/entity/Team.java
+++ b/src/main/java/com/saerok/showing/api/domain/team/entity/Team.java
@@ -1,0 +1,64 @@
+package com.saerok.showing.api.domain.team.entity;
+
+import com.saerok.showing.api.domain.team.dto.request.TeamCreateRequest;
+import com.saerok.showing.api.domain.member.entity.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "team")
+public class Team {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "team_id")
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @OneToOne
+    @JoinColumn(name = "leader_id", nullable = false)
+    private Member leader;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "team", fetch = FetchType.LAZY)
+    private List<Member> members = new ArrayList<>();
+
+    public static Team toEntity(TeamCreateRequest request, Member leader) {
+        return Team.builder()
+            .name(request.getName())
+            .leader(leader)
+            .build();
+    }
+
+    public boolean isLeader(Member member) {
+        return leader != null && leader.getId().equals(member.getId());
+    }
+
+    public void addMember(Member member) {
+        members.add(member);
+        member.setTeam(this);
+    }
+}

--- a/src/main/java/com/saerok/showing/api/domain/team/repository/TeamRepository.java
+++ b/src/main/java/com/saerok/showing/api/domain/team/repository/TeamRepository.java
@@ -1,0 +1,15 @@
+package com.saerok.showing.api.domain.team.repository;
+
+import com.saerok.showing.api.domain.team.entity.Team;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TeamRepository extends JpaRepository<Team, Long> {
+
+    @Query("SELECT t FROM Team t JOIN FETCH t.members WHERE t.id = :teamId")
+    Optional<Team> findByIdWithMembers(@Param("teamId") Long teamId);
+}

--- a/src/main/java/com/saerok/showing/api/domain/team/service/TeamService.java
+++ b/src/main/java/com/saerok/showing/api/domain/team/service/TeamService.java
@@ -1,0 +1,130 @@
+package com.saerok.showing.api.domain.team.service;
+
+import com.saerok.showing.api.domain.member.entity.Member;
+import com.saerok.showing.api.domain.member.repository.MemberRepository;
+import com.saerok.showing.api.domain.team.dto.request.TeamCreateRequest;
+import com.saerok.showing.api.domain.team.dto.response.TeamMemberResponse;
+import com.saerok.showing.api.domain.team.entity.Team;
+import com.saerok.showing.api.domain.team.repository.TeamRepository;
+import com.saerok.showing.api.global.auth.util.LoginMemberProvider;
+import com.saerok.showing.api.global.exception.ErrorCode;
+import com.saerok.showing.api.global.exception.ShowingException;
+import java.util.Comparator;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TeamService {
+
+    private final TeamRepository teamRepository;
+    private final MemberRepository memberRepository;
+    private final LoginMemberProvider loginMemberProvider;
+
+    @Transactional
+    public Long save(TeamCreateRequest request) {
+        Member member = loginMemberProvider.getCurrentLoginMember();
+        validateNotAlreadyJoined(member);
+        Team team = Team.toEntity(request, member);
+        teamRepository.save(team);
+        team.addMember(member);
+        memberRepository.save(member);
+        return team.getId();
+    }
+
+    @Transactional
+    public Long joinTeam(Long teamId) {
+        Member member = loginMemberProvider.getCurrentLoginMember();
+        validateNotAlreadyJoined(member);
+        Team team = findById(teamId);
+        member.joinTeam(team);
+        memberRepository.save(member);
+        return team.getId();
+    }
+
+    @Transactional
+    public Long leaveTeam(Long teamId) {
+        Member member = loginMemberProvider.getCurrentLoginMember();
+        Team team = findById(teamId);
+        validateIsMemberOfTeam(member, team);
+        if (team.isLeader(member)) {
+            deleteTeamAsLeader(team);
+        } else {
+            leaveTeamAsMember(member);
+        }
+        return teamId;
+    }
+
+    @Transactional(readOnly = true)
+    public List<TeamMemberResponse> getMyTeamMembers() {
+        Member member = loginMemberProvider.getCurrentLoginMember();
+        Team team = getTeamOfCurrentMember();
+        List<Member> members = team.getMembers();
+        return members.stream()
+            .sorted(Comparator.comparing(Member::getCreatedAt))
+            .map(TeamMemberResponse::toDto)
+            .toList();
+    }
+
+    @Transactional
+    public Long delete(Long teamId) {
+        Team team = findById(teamId);
+        assertLeader(team);
+        List<Member> members = team.getMembers();
+        removeAllMembersFromTeam(team);
+        teamRepository.deleteById(teamId);
+        return teamId;
+    }
+
+    private Team findById(Long teamId) {
+        return teamRepository.findById(teamId)
+            .orElseThrow(() -> ShowingException.from(ErrorCode.TEAM_NOT_FOUND));
+    }
+
+    private Team getTeamOfCurrentMember() {
+        Member currentMember = loginMemberProvider.getCurrentLoginMember();
+        if (currentMember.getTeam() == null) {
+            throw ShowingException.from(ErrorCode.NOT_MEMBER_OF_TEAM);
+        }
+        return teamRepository.findByIdWithMembers(currentMember.getTeam().getId())
+            .orElseThrow(() -> ShowingException.from(ErrorCode.TEAM_NOT_FOUND));
+    }
+
+    private void validateNotAlreadyJoined(Member member) {
+        if (member.getTeam() != null) {
+            throw ShowingException.from(ErrorCode.ALREADY_JOINED_TEAM);
+        }
+    }
+
+    private void validateIsMemberOfTeam(Member member, Team team) {
+        if (member.getTeam() == null || !team.getId().equals(member.getTeam().getId())) {
+            throw ShowingException.from(ErrorCode.NOT_MEMBER_OF_TEAM);
+        }
+    }
+
+    private void assertLeader(Team team) {
+        Member currentUser = loginMemberProvider.getCurrentLoginMember();
+        if (!team.isLeader(currentUser)) {
+            throw ShowingException.from(ErrorCode.NO_TEAM_LEADER_PERMISSION);
+        }
+    }
+
+    private void deleteTeamAsLeader(Team team) {
+        for (Member m : team.getMembers()) {
+            m.leaveTeam();
+            memberRepository.save(m);
+        }
+        teamRepository.delete(team);
+    }
+
+    private void leaveTeamAsMember(Member member) {
+        member.leaveTeam();
+        memberRepository.save(member);
+    }
+
+    private void removeAllMembersFromTeam(Team team) {
+        team.getMembers().forEach(member -> member.setTeam(null));
+    }
+}

--- a/src/main/java/com/saerok/showing/api/global/auth/service/CustomOAuth2MemberService.java
+++ b/src/main/java/com/saerok/showing/api/global/auth/service/CustomOAuth2MemberService.java
@@ -60,6 +60,7 @@ public class CustomOAuth2MemberService extends DefaultOAuth2UserService {
             .profileImage(oAuth2Response.getProfileImage())
             .role(Role.MEMBER)
             .loginType(LoginType.from(oAuth2Response.getProvider()))
+            .team(null)
             .build();
     }
 

--- a/src/main/java/com/saerok/showing/api/global/exception/ErrorCode.java
+++ b/src/main/java/com/saerok/showing/api/global/exception/ErrorCode.java
@@ -33,6 +33,9 @@ public enum ErrorCode {
     MEMBER_NOT_ADMIN(HttpStatus.FORBIDDEN, "관리자 권한이 필요합니다."),
     REVIEW_WRITER_MISMATCH(HttpStatus.FORBIDDEN, "요청한 리뷰에 대해 접근 권한이 아닙니다."),
     ROUTE_MAKER_MISMATCH(HttpStatus.FORBIDDEN, "요청한 여행코스에 대해 접근 권한이 없습니다."),
+    NO_TEAM_LEADER_PERMISSION(HttpStatus.FORBIDDEN, "요청한 사항은 팀 리더만 가능합니다."),
+    ALREADY_JOINED_TEAM(HttpStatus.FORBIDDEN, "이미 팀에 가입되어 있습니다."),
+    NOT_MEMBER_OF_TEAM(HttpStatus.FORBIDDEN, "요청한 팀에 소속되어 있지 않습니다."),
 
     // 404: NOT FOUND (리소스를 찾을 수 없음)
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다."),
@@ -43,6 +46,7 @@ public enum ErrorCode {
     REVIEW_TARGET_NOT_FOUND(HttpStatus.NOT_FOUND, "리뷰를 찾을 수 없습니다."),
     ROUTE_NOT_FOUND(HttpStatus.NOT_FOUND, "나만의 경로를 찾을 수 없습니다."),
     ROUTE_PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "여행코스 내 장소를 찾을 수 없습니다."),
+    TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "팀을 찾을 수 없습니다."),
     PROFILE_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "프로필 이미지를 찾을 수 없습니다."),
     TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "토큰을 찾을 수 없습니다."),
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "리뷰를 찾을 수 없습니다."),


### PR DESCRIPTION
## ⭐️ Overview

> #23

팀 API를 구현했습니다.

## 🔧 Tasks

- 팀 생성 API 구현
- 팀 삭제 API 구현
- 팀 가입 API 구현
- 팀 탈퇴 API 구현
- 팀 내 팀원 목록 조회

## 📝 Additional Notes

- 추후 팀 코드 기반 가입 기능으로 리팩토링 예정입니다.

## 📸 Screenshot

### 팀 API 목록  
<img src="https://github.com/user-attachments/assets/4ce20e9d-abef-4841-9378-858ff52ad8ed" width="600"/>

### 팀 생성  
<img src="https://github.com/user-attachments/assets/da0b2619-d212-4a23-b5d0-c231ad75c26c" width="600"/>

### 팀 삭제  
<img src="https://github.com/user-attachments/assets/b15156a2-4260-4523-b619-3ac296122ba8" width="600"/>

### 팀 가입  
<img src="https://github.com/user-attachments/assets/04b44cee-05c1-49cb-a7a9-7f2c2c0c17a9" width="600"/>

### 팀 탈퇴  
<img src="https://github.com/user-attachments/assets/cc805506-be08-48aa-aa9e-6188826a0fc0" width="600"/>

### 팀원 목록 조회  
<img src="https://github.com/user-attachments/assets/71ccb0b6-dd5f-4706-9ed3-4ca7b6663d4a" width="600"/>
