### PR TITLE
refactor: 팀 생성 및 입장 시 비밀번호 기능 구현 완료

### DIFF
--- a/src/main/java/com/saerok/showing/api/domain/team/controller/TeamController.java
+++ b/src/main/java/com/saerok/showing/api/domain/team/controller/TeamController.java
@@ -49,6 +49,7 @@ public class TeamController {
         description = """
             [모든 Role 가능] 팀에 가입합니다.<br>
             이미 팀이 존재하거나 요청한 팀에 가입된 경우는 가입되지 않습니다.
+            입장할 팁의 아이디와 비밀번호가 필요합니다.
             """
     )
     @PreAuthorize("hasRole('MEMBER')")

--- a/src/main/java/com/saerok/showing/api/domain/team/controller/TeamController.java
+++ b/src/main/java/com/saerok/showing/api/domain/team/controller/TeamController.java
@@ -1,6 +1,7 @@
 package com.saerok.showing.api.domain.team.controller;
 
 import com.saerok.showing.api.domain.team.dto.request.TeamCreateRequest;
+import com.saerok.showing.api.domain.team.dto.request.TeamJoinRequest;
 import com.saerok.showing.api.domain.team.dto.response.TeamMemberResponse;
 import com.saerok.showing.api.domain.team.service.TeamService;
 import com.saerok.showing.api.global.response.ApiResponse;
@@ -53,9 +54,9 @@ public class TeamController {
     @PreAuthorize("hasRole('MEMBER')")
     @PostMapping("/{teamId}/join")
     public ApiResponse<Long> joinTeam(
-        @PathVariable(name = "teamId") Long teamId
+        @Valid @RequestBody TeamJoinRequest request
     ) {
-        Long id = teamService.joinTeam(teamId);
+        Long id = teamService.joinTeam(request);
         return ApiResponse.success(id);
     }
 

--- a/src/main/java/com/saerok/showing/api/domain/team/dto/request/TeamCreateRequest.java
+++ b/src/main/java/com/saerok/showing/api/domain/team/dto/request/TeamCreateRequest.java
@@ -3,6 +3,7 @@ package com.saerok.showing.api.domain.team.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -12,6 +13,17 @@ public class TeamCreateRequest {
 
     @NotNull
     @Size(min = 2, max = 30)
-    @Schema(description = "팀(그룹, 소속, 학교, 단체) 이름을 입력합니다, 팀 이름은 2 ~ 30글자 입니다.", example = "금화초등학교")
+    @Schema(
+        description = "팀(그룹, 소속, 학교, 단체) 이름을 입력합니다, 팀 이름은 2 ~ 30글자 입니다.",
+        example = "금화초등학교"
+    )
     private String name;
+
+    @NotNull
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{4,30}$")
+    @Schema(
+        description = "팀 입장 비밀번호입니다. 영문과 숫자를 조합한 4~30자 이내의 문자열이어야 합니다.",
+        example = "team2025"
+    )
+    private String password;
 }

--- a/src/main/java/com/saerok/showing/api/domain/team/dto/request/TeamJoinRequest.java
+++ b/src/main/java/com/saerok/showing/api/domain/team/dto/request/TeamJoinRequest.java
@@ -1,0 +1,26 @@
+package com.saerok.showing.api.domain.team.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TeamJoinRequest {
+
+    @NotNull
+    @Schema(description = "가입할 팀 ID입니다.", example = "1")
+    private Long teamId;
+
+    @NotNull
+    @Size(min = 4, max = 30)
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{4,30}$")
+    @Schema(
+        description = "팀 입장 시 사용하는 비밀번호입니다. 영문자와 숫자를 조합한 4~30자입니다.",
+        example = "team2025"
+    )
+    private String password;
+}

--- a/src/main/java/com/saerok/showing/api/domain/team/entity/Team.java
+++ b/src/main/java/com/saerok/showing/api/domain/team/entity/Team.java
@@ -38,6 +38,9 @@ public class Team {
     @Column(name = "name", nullable = false)
     private String name;
 
+    @Column(name = "password", nullable = false)
+    private String password;
+
     @OneToOne
     @JoinColumn(name = "leader_id", nullable = false)
     private Member leader;
@@ -46,9 +49,10 @@ public class Team {
     @OneToMany(mappedBy = "team", fetch = FetchType.LAZY)
     private List<Member> members = new ArrayList<>();
 
-    public static Team toEntity(TeamCreateRequest request, Member leader) {
+    public static Team toEntity(TeamCreateRequest request, Member leader, String encryptedPassword) {
         return Team.builder()
             .name(request.getName())
+            .password(encryptedPassword)
             .leader(leader)
             .build();
     }

--- a/src/main/java/com/saerok/showing/api/domain/team/service/TeamService.java
+++ b/src/main/java/com/saerok/showing/api/domain/team/service/TeamService.java
@@ -3,6 +3,7 @@ package com.saerok.showing.api.domain.team.service;
 import com.saerok.showing.api.domain.member.entity.Member;
 import com.saerok.showing.api.domain.member.repository.MemberRepository;
 import com.saerok.showing.api.domain.team.dto.request.TeamCreateRequest;
+import com.saerok.showing.api.domain.team.dto.request.TeamJoinRequest;
 import com.saerok.showing.api.domain.team.dto.response.TeamMemberResponse;
 import com.saerok.showing.api.domain.team.entity.Team;
 import com.saerok.showing.api.domain.team.repository.TeamRepository;
@@ -12,6 +13,7 @@ import com.saerok.showing.api.global.exception.ShowingException;
 import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,13 +23,15 @@ public class TeamService {
 
     private final TeamRepository teamRepository;
     private final MemberRepository memberRepository;
+    private final BCryptPasswordEncoder passwordEncoder;
     private final LoginMemberProvider loginMemberProvider;
 
     @Transactional
     public Long save(TeamCreateRequest request) {
         Member member = loginMemberProvider.getCurrentLoginMember();
         validateNotAlreadyJoined(member);
-        Team team = Team.toEntity(request, member);
+        String encodedPassword = passwordEncoder.encode(request.getPassword());
+        Team team = Team.toEntity(request, member, encodedPassword);
         teamRepository.save(team);
         team.addMember(member);
         memberRepository.save(member);
@@ -35,10 +39,11 @@ public class TeamService {
     }
 
     @Transactional
-    public Long joinTeam(Long teamId) {
+    public Long joinTeam(TeamJoinRequest request) {
         Member member = loginMemberProvider.getCurrentLoginMember();
         validateNotAlreadyJoined(member);
-        Team team = findById(teamId);
+        Team team = findById(request.getTeamId());
+        validateTeamPassword(team, request.getPassword());
         member.joinTeam(team);
         memberRepository.save(member);
         return team.getId();
@@ -95,6 +100,12 @@ public class TeamService {
     private void validateNotAlreadyJoined(Member member) {
         if (member.getTeam() != null) {
             throw ShowingException.from(ErrorCode.ALREADY_JOINED_TEAM);
+        }
+    }
+
+    private void validateTeamPassword(Team team, String rawPassword) {
+        if (!passwordEncoder.matches(rawPassword, team.getPassword())) {
+            throw ShowingException.from(ErrorCode.INVALID_TEAM_PASSWORD);
         }
     }
 

--- a/src/main/java/com/saerok/showing/api/global/config/SecurityConfig.java
+++ b/src/main/java/com/saerok/showing/api/global/config/SecurityConfig.java
@@ -25,6 +25,7 @@ import org.springframework.security.config.annotation.web.configurers.AuthorizeH
 import org.springframework.security.config.annotation.web.configurers.ExceptionHandlingConfigurer;
 import org.springframework.security.config.annotation.web.configurers.oauth2.client.OAuth2LoginConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
@@ -129,12 +130,16 @@ public class SecurityConfig {
         return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
     }
 
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
     private void configureAuthorization(
         AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry auth) {
         auth
             .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
             .requestMatchers(SecurityUrlConstants.PUBLIC_URLS).permitAll()
-            // .anyRequest().permitAll()
             .anyRequest().authenticated(); // TODO: 운영 시 이 부분을 인증 필요하게
     }
 

--- a/src/main/java/com/saerok/showing/api/global/exception/ErrorCode.java
+++ b/src/main/java/com/saerok/showing/api/global/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     UNSUPPORTED_AUTH_TOKEN(HttpStatus.UNAUTHORIZED, "지원하지 않는 토큰입니다."),
     INVALID_SIGNATURE_TOKEN(HttpStatus.UNAUTHORIZED, "토큰 서명이 유효하지 않습니다."),
     EMPTY_OR_NULL_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 비어 있거나 null입니다."),
+    INVALID_TEAM_PASSWORD(HttpStatus.UNAUTHORIZED, "팀 입장 비밀번호가 올바르지 않습니다."),
 
     // 403: FORBIDDEN (권한 없음)
     FORBIDDEN(HttpStatus.FORBIDDEN, "접근이 거부되었습니다."),

--- a/src/main/java/com/saerok/showing/api/global/utils/DistanceUtil.java
+++ b/src/main/java/com/saerok/showing/api/global/utils/DistanceUtil.java
@@ -8,9 +8,7 @@ public class DistanceUtil {
 
     private static final double EARTH_RADIUS_M = 6371000; // meters
 
-    /**
-     * 두 좌표 간 거리(m) 계산
-     */
+    // 두 좌표 간 거리 계산
     public static double calculateDistance(double lon1, double lat1, double lon2, double lat2) {
         double dLat = Math.toRadians(lat2 - lat1);
         double dLon = Math.toRadians(lon2 - lon1);
@@ -21,9 +19,7 @@ public class DistanceUtil {
         return EARTH_RADIUS_M * c;
     }
 
-    /**
-     * 반경(m) 기준 사각형 박스 계산
-     */
+    // 반경 기준 사각형 박스 계산
     public static BoundingBox getBoundingBox(double lon, double lat, double radiusMeters) {
         double latDelta = radiusMeters / 111000.0;
         double lonDelta = radiusMeters / (111000.0 * Math.cos(Math.toRadians(lat)));
@@ -33,9 +29,7 @@ public class DistanceUtil {
         );
     }
 
-    /**
-     * Locatable 객체 리스트에서 반경 내 가까운 요소 반환
-     */
+    // 반경 내 가까운 후보지들 리스트 반환
     public static <T extends Locatable> List<T> filterNearbyPositions(
         List<T> candidates,
         double baseX,
@@ -53,17 +47,7 @@ public class DistanceUtil {
             .collect(Collectors.toList());
     }
 
-    /**
-     * 사각형 범위를 나타내는 record
-     */
-    public record BoundingBox(double minLat, double maxLat, double minLon, double maxLon) {
+    public record BoundingBox(double minLat, double maxLat, double minLon, double maxLon) { }
 
-    }
-
-    /**
-     * 거리 정보 포함된 제네릭 내부 record
-     */
-    private record WithDistance<T>(T item, double distance) {
-
-    }
+    private record WithDistance<T>(T item, double distance) { }
 }


### PR DESCRIPTION
## ⭐️ Overview

> #29

팀 생성 및 입장 시 비밀번호 기능을 추가했습니다.  
팀 리더는 팀 생성 시 비밀번호를 설정하고, 다른 사용자는 입장 시 해당 비밀번호를 입력해야 합니다.

## 🔧 Tasks

- 팀 생성 시 비밀번호 입력 및 암호화 저장
- 팀 입장 시 비밀번호 검증 로직 추가
- 관련 DTO 및 엔티티 필드 추가
- 유효성 검사 및 예외 처리

## 📝 Additional Notes

- 비밀번호는 영문 + 숫자 조합의 4~30자이며, 서버에서 암호화 처리됩니다.
