### PR TITLE
feat: 투표 기능 구현 완료

### DIFF
--- a/src/main/java/com/saerok/showing/api/domain/comment/entity/Comment.java
+++ b/src/main/java/com/saerok/showing/api/domain/comment/entity/Comment.java
@@ -2,6 +2,7 @@ package com.saerok.showing.api.domain.comment.entity;
 
 import com.saerok.showing.api.domain.member.entity.Member;
 import com.saerok.showing.api.domain.comment.dto.request.CommentCreateRequest;
+import com.saerok.showing.api.domain.poll.entity.Poll;
 import com.saerok.showing.api.domain.post.entity.Post;
 import com.saerok.showing.api.global.entity.BaseEntity;
 import com.saerok.showing.api.global.exception.ErrorCode;
@@ -42,6 +43,10 @@ public class Comment extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "poll_id")
+    private Poll poll;
 
     @Column(name = "comment", nullable = false, length = 1000)
     private String comment;

--- a/src/main/java/com/saerok/showing/api/domain/like/entity/LikeTargetType.java
+++ b/src/main/java/com/saerok/showing/api/domain/like/entity/LikeTargetType.java
@@ -9,7 +9,9 @@ public enum LikeTargetType {
 
     POST("POST", "게시글"),
     COMMENT("COMMENT", "댓글"),
-    ROUTE("ROUTE", "여행 경로");
+    ROUTE("ROUTE", "여행 경로"),
+    POLL("POLL", "투표"),
+    POLL_OPTION("POLL_OPTION", "투표 후보 여행 경로");
 
     private final String key;
     private final String name;

--- a/src/main/java/com/saerok/showing/api/domain/like/service/LikeService.java
+++ b/src/main/java/com/saerok/showing/api/domain/like/service/LikeService.java
@@ -5,6 +5,8 @@ import com.saerok.showing.api.domain.comment.service.CommentService;
 import com.saerok.showing.api.domain.like.dto.request.LikeToggleRequest;
 import com.saerok.showing.api.domain.like.entity.LikeTargetType;
 import com.saerok.showing.api.domain.member.entity.Member;
+import com.saerok.showing.api.domain.poll.entity.Poll;
+import com.saerok.showing.api.domain.poll.service.PollService;
 import com.saerok.showing.api.domain.post.entity.Post;
 import com.saerok.showing.api.domain.like.entity.Like;
 import com.saerok.showing.api.domain.like.repository.LikeRepository;
@@ -28,27 +30,21 @@ public class LikeService {
     private final PostService postService;
     private final CommentService commentService;
     private final RouteService routeService;
+    private final PollService pollService;
 
     @Transactional
     public boolean toggleLike(LikeToggleRequest request) {
         Member member = loginMemberProvider.getCurrentLoginMember();
         Long targetId = request.getTargetId();
         LikeTargetType type = request.getLikeTargetType();
-        switch (type) {
-            case POST -> {
-                Post post = postService.findById(targetId);
-                return handleToggle(member, request, post);
-            }
-            case COMMENT -> {
-                Comment comment = commentService.findById(targetId);
-                return handleToggle(member, request, comment);
-            }
-            case ROUTE -> {
-                Route route = routeService.findById(targetId);
-                return handleToggle(member, request, route);
-            }
+        return switch (type) {
+            case POST -> handleToggle(member, request, postService.findById(targetId));
+            case COMMENT -> handleToggle(member, request, commentService.findById(targetId));
+            case ROUTE -> handleToggle(member, request, routeService.findById(targetId));
+            case POLL -> handleToggle(member, request, pollService.findById(targetId));
+            case POLL_OPTION -> handleToggleForPollOption(member, request, routeService.findById(targetId));
             default -> throw ShowingException.from(ErrorCode.INVALID_LIKE_TARGET_TYPE);
-        }
+        };
     }
 
     private boolean handleToggle(Member member, LikeToggleRequest request, Post post) {
@@ -82,6 +78,34 @@ public class LikeService {
     private boolean handleToggle(Member member, LikeToggleRequest request, Route route) {
         Optional<Like> existingLike = likeRepository.findByMemberAndTargetIdAndTargetType(
             member, request.getTargetId(), LikeTargetType.ROUTE
+        );
+        if (existingLike.isPresent()) {
+            likeRepository.delete(existingLike.get());
+            route.decreaseLikeCount();
+            return false;
+        }
+        likeRepository.save(Like.toEntity(member, request));
+        route.increaseLikeCount();
+        return true;
+    }
+
+    private boolean handleToggle(Member member, LikeToggleRequest request, Poll poll) {
+        Optional<Like> existingLike = likeRepository.findByMemberAndTargetIdAndTargetType(
+            member, request.getTargetId(), LikeTargetType.POLL
+        );
+        if (existingLike.isPresent()) {
+            likeRepository.delete(existingLike.get());
+            poll.decreaseLikeCount();
+            return false;
+        }
+        likeRepository.save(Like.toEntity(member, request));
+        poll.increaseLikeCount();
+        return true;
+    }
+
+    private boolean handleToggleForPollOption(Member member, LikeToggleRequest request, Route route) {
+        Optional<Like> existingLike = likeRepository.findByMemberAndTargetIdAndTargetType(
+            member, request.getTargetId(), LikeTargetType.POLL_OPTION
         );
         if (existingLike.isPresent()) {
             likeRepository.delete(existingLike.get());

--- a/src/main/java/com/saerok/showing/api/domain/member/dto/response/MyPageResponse.java
+++ b/src/main/java/com/saerok/showing/api/domain/member/dto/response/MyPageResponse.java
@@ -18,7 +18,7 @@ public class MyPageResponse {
 
     private int postCount;
 
-     private List<RouteSummaryResponse> routes;
+    private List<RouteSummaryResponse> routes;
 
     public static MyPageResponse toDto(
         Member member,

--- a/src/main/java/com/saerok/showing/api/domain/poll/controller/PollController.java
+++ b/src/main/java/com/saerok/showing/api/domain/poll/controller/PollController.java
@@ -1,0 +1,104 @@
+package com.saerok.showing.api.domain.poll.controller;
+
+import com.saerok.showing.api.domain.poll.dto.request.PollCandidateRegisterRequest;
+import com.saerok.showing.api.domain.poll.dto.request.PollCreateRequest;
+import com.saerok.showing.api.domain.poll.dto.request.PollUpdateRequest;
+import com.saerok.showing.api.domain.poll.dto.response.PollDetailResponse;
+import com.saerok.showing.api.domain.poll.service.PollService;
+import com.saerok.showing.api.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/poll")
+@RequiredArgsConstructor
+@Tag(name = "Poll", description = "투표 관리")
+public class PollController {
+
+    private final PollService pollService;
+
+    @Operation(
+        summary = "투표 등록",
+        description = """
+            [모든 Role 가능] 투표를 등록합니다.
+            """
+    )
+    @PreAuthorize("hasRole('MEMBER')")
+    @PostMapping("")
+    public ApiResponse<Long> createPoll(
+        @Valid @RequestBody PollCreateRequest request
+    ) {
+        Long id = pollService.save(request);
+        return ApiResponse.success(id);
+    }
+
+    @Operation(
+        summary = "투표 후보 조회",
+        description = "[모든 Role 가능] 투표에 등록된 Route 후보 리스트를 조회합니다."
+    )
+    @PreAuthorize("hasRole('MEMBER')")
+    @GetMapping("/{pollId}")
+    public ApiResponse<PollDetailResponse> getPoll(
+        @PathVariable(name = "pollId") Long pollId
+    ) {
+        PollDetailResponse response = pollService.getPoll(pollId);
+        return ApiResponse.success(response);
+    }
+
+    @Operation(
+        summary = "투표 후보 등록",
+        description = """
+            [모든 Role 가능] 투표에 여행 경로(Route)를 하나 등록합니다.<br>
+            자신이 생성한 여행 경로 중 하나를 투표 후보로 올릴 수 있으며,<br>
+            동일한 경로는 중복 등록할 수 없습니다.
+            """
+    )
+    @PreAuthorize("hasRole('MEMBER')")
+    @PostMapping("/{pollId}/candidates")
+    public ApiResponse<Void> registerCandidate(
+        @PathVariable Long pollId,
+        @Valid @RequestBody PollCandidateRegisterRequest request
+    ) {
+        pollService.registerCandidate(pollId, request);
+        return ApiResponse.success();
+    }
+
+    @Operation(
+        summary = "투표 수정",
+        description = "[모든 Role 가능] 투표 ID를 기준으로 내용 및 투표 상태를 수정합니다."
+    )
+    @PreAuthorize("hasRole('MEMBER')")
+    @PatchMapping("/{pollId}")
+    public ApiResponse<Long> update(
+        @PathVariable(name = "pollId") Long pollId,
+        @Valid @RequestBody PollUpdateRequest request
+    ) {
+        Long id = pollService.update(pollId, request);
+        return ApiResponse.success(id);
+    }
+
+    @Operation(
+        summary = "투표 삭제",
+        description = "[모든 Role 가능] 투표 ID를 기준으로 투표를 삭제합니다."
+    )
+    @PreAuthorize("hasRole('MEMBER')")
+    @DeleteMapping("/{pollId}")
+    public ApiResponse<Long> delete(
+        @PathVariable(name = "pollId") Long pollId
+    ) {
+        Long id = pollService.delete(pollId);
+        return ApiResponse.success(id);
+    }
+
+}

--- a/src/main/java/com/saerok/showing/api/domain/poll/dto/request/PollCandidateRegisterRequest.java
+++ b/src/main/java/com/saerok/showing/api/domain/poll/dto/request/PollCandidateRegisterRequest.java
@@ -1,0 +1,13 @@
+package com.saerok.showing.api.domain.poll.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class PollCandidateRegisterRequest {
+
+    @NotNull
+    @Schema(description = "후보로 등록할 Route ID", example = "1")
+    private Long routeId;
+}

--- a/src/main/java/com/saerok/showing/api/domain/poll/dto/request/PollCreateRequest.java
+++ b/src/main/java/com/saerok/showing/api/domain/poll/dto/request/PollCreateRequest.java
@@ -1,0 +1,31 @@
+package com.saerok.showing.api.domain.poll.dto.request;
+
+import com.saerok.showing.api.domain.poll.entity.PollStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PollCreateRequest {
+
+    @NotNull
+    @Size(max = 50, message = "투표 제목은 최대 50자까지 입력할 수 있습니다.")
+    @Schema(description = "투표 제목", example = "8/16일 현장체험학습으로 어디를 가면 좋을까?")
+    private String title;
+
+    @NotNull
+    @Schema(description = "투표 타입 (예: READY, ONGOING, CLOSED", example = "ONGOING")
+    private PollStatus pollStatus;
+
+    @NotNull
+    @Schema(description = "투표 시작일 (YYYY-MM-DD)", example = "2025-08-16")
+    private LocalDate startDate;
+
+    @NotNull
+    @Schema(description = "투표 종료일 (YYYY-MM-DD)", example = "2025-08-17")
+    private LocalDate endDate;
+}

--- a/src/main/java/com/saerok/showing/api/domain/poll/dto/request/PollUpdateRequest.java
+++ b/src/main/java/com/saerok/showing/api/domain/poll/dto/request/PollUpdateRequest.java
@@ -1,0 +1,31 @@
+package com.saerok.showing.api.domain.poll.dto.request;
+
+import com.saerok.showing.api.domain.poll.entity.PollStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PollUpdateRequest {
+
+    @NotNull
+    @Size(max = 50, message = "투표 제목은 최대 50자까지 입력할 수 있습니다.")
+    @Schema(description = "투표 제목", example = "8/16일 현장체험학습으로 어디를 가면 좋을까요?")
+    private String title;
+
+    @NotNull
+    @Schema(description = "투표 타입 (예: READY, ONGOING, CLOSED", example = "CLOSED")
+    private PollStatus pollStatus;
+
+    @NotNull
+    @Schema(description = "투표 시작일 (YYYY-MM-DD)", example = "2025-08-16")
+    private LocalDate startDate;
+
+    @NotNull
+    @Schema(description = "투표 종료일 (YYYY-MM-DD)", example = "2025-08-18")
+    private LocalDate endDate;
+}

--- a/src/main/java/com/saerok/showing/api/domain/poll/dto/response/PollDetailResponse.java
+++ b/src/main/java/com/saerok/showing/api/domain/poll/dto/response/PollDetailResponse.java
@@ -1,0 +1,52 @@
+package com.saerok.showing.api.domain.poll.dto.response;
+
+import com.saerok.showing.api.domain.member.entity.Member;
+import com.saerok.showing.api.domain.poll.entity.Poll;
+import com.saerok.showing.api.domain.poll.entity.PollStatus;
+import com.saerok.showing.api.domain.route.dto.response.RouteSummaryResponse;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PollDetailResponse {
+
+    private Long id;
+
+    private String writer;
+
+    private String writerProfileImage;
+
+    private String title;
+
+    private PollStatus pollStatus;
+
+    private LocalDate startDate;
+
+    private LocalDate endDate;
+
+    private int commentCount;
+
+    private List<RouteSummaryResponse> routes;
+
+    public static PollDetailResponse toDto(
+        Poll poll,
+        Member member,
+        int commentCount,
+        List<RouteSummaryResponse> routes
+    ) {
+        return PollDetailResponse.builder()
+            .id(poll.getId())
+            .writer(member.getName())
+            .writer(member.getProfileImage())
+            .title(poll.getTitle())
+            .pollStatus(poll.getPollStatus())
+            .startDate(poll.getStartDate())
+            .endDate(poll.getEndDate())
+            .commentCount(commentCount)
+            .routes(routes)
+            .build();
+    }
+}

--- a/src/main/java/com/saerok/showing/api/domain/poll/entity/Poll.java
+++ b/src/main/java/com/saerok/showing/api/domain/poll/entity/Poll.java
@@ -1,0 +1,108 @@
+package com.saerok.showing.api.domain.poll.entity;
+
+import com.saerok.showing.api.domain.member.entity.Member;
+import com.saerok.showing.api.domain.poll.dto.request.PollCreateRequest;
+import com.saerok.showing.api.domain.poll.dto.request.PollUpdateRequest;
+import com.saerok.showing.api.domain.route.entity.Route;
+import com.saerok.showing.api.global.entity.BaseEntity;
+import com.saerok.showing.api.global.exception.ErrorCode;
+import com.saerok.showing.api.global.exception.ShowingException;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "poll")
+public class Poll extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "poll_id")
+    private Long id;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "poll_type", nullable = false)
+    private PollStatus pollStatus;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate;
+
+    @Column(name = "like_count", nullable = false)
+    private int likeCount;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @OneToMany(mappedBy = "poll")
+    private List<Route> routeOptions = new ArrayList<>();
+
+    public static Poll toEntity(PollCreateRequest request, Member member) {
+        return Poll.builder()
+            .title(request.getTitle())
+            .pollStatus(request.getPollStatus())
+            .startDate(request.getStartDate())
+            .endDate(request.getEndDate())
+            .likeCount(0)
+            .member(member)
+            .build();
+    }
+
+    public void validateOwner(Poll poll, Member currentMember) {
+        if (!poll.getMember().getId().equals(currentMember.getId())) {
+            throw ShowingException.from(ErrorCode.POLL_MAKER_MISMATCH);
+        }
+    }
+
+    public void update(PollUpdateRequest request) {
+        this.title = request.getTitle();
+        this.pollStatus = request.getPollStatus();
+        this.startDate = request.getStartDate();
+        this.endDate = request.getEndDate();
+    }
+
+    public void registerRouteOption(Route route) {
+        if (this.routeOptions.contains(route)) {
+            throw ShowingException.from(ErrorCode.DUPLICATE_ROUTE_REGISTERED_IN_POLL);
+        }
+        this.routeOptions.add(route);
+        route.setPoll(this);
+    }
+
+    public void increaseLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decreaseLikeCount() {
+        if (this.likeCount > 0) {
+            this.likeCount--;
+        }
+    }
+}

--- a/src/main/java/com/saerok/showing/api/domain/poll/entity/PollStatus.java
+++ b/src/main/java/com/saerok/showing/api/domain/poll/entity/PollStatus.java
@@ -1,0 +1,16 @@
+package com.saerok.showing.api.domain.poll.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PollStatus {
+
+    READY("READY", "대기 중"),
+    ONGOING("ONGOING", "진행 중"),
+    CLOSED("CLOSED", "종료됨");
+
+    private final String key;
+    private final String name;
+}

--- a/src/main/java/com/saerok/showing/api/domain/poll/repository/PollRepository.java
+++ b/src/main/java/com/saerok/showing/api/domain/poll/repository/PollRepository.java
@@ -1,0 +1,12 @@
+package com.saerok.showing.api.domain.poll.repository;
+
+import com.saerok.showing.api.domain.poll.entity.Poll;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface PollRepository extends JpaRepository<Poll, Long> {
+
+    @Query("SELECT COUNT(c) FROM Comment c WHERE c.poll.id = :pollId")
+    int countCommentsOfPoll(@Param("pollId") Long pollId);
+}

--- a/src/main/java/com/saerok/showing/api/domain/poll/service/PollService.java
+++ b/src/main/java/com/saerok/showing/api/domain/poll/service/PollService.java
@@ -1,0 +1,87 @@
+package com.saerok.showing.api.domain.poll.service;
+
+import com.saerok.showing.api.domain.member.entity.Member;
+import com.saerok.showing.api.domain.place.dto.response.PlaceSummaryResponse;
+import com.saerok.showing.api.domain.poll.dto.request.PollCandidateRegisterRequest;
+import com.saerok.showing.api.domain.poll.dto.request.PollCreateRequest;
+import com.saerok.showing.api.domain.poll.dto.request.PollUpdateRequest;
+import com.saerok.showing.api.domain.poll.dto.response.PollDetailResponse;
+import com.saerok.showing.api.domain.poll.entity.Poll;
+import com.saerok.showing.api.domain.poll.repository.PollRepository;
+import com.saerok.showing.api.domain.route.dto.response.RouteSummaryResponse;
+import com.saerok.showing.api.domain.route.entity.Route;
+import com.saerok.showing.api.domain.route.service.RouteService;
+import com.saerok.showing.api.global.auth.util.LoginMemberProvider;
+import com.saerok.showing.api.global.exception.ErrorCode;
+import com.saerok.showing.api.global.exception.ShowingException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PollService {
+
+    private final PollRepository pollRepository;
+    private final LoginMemberProvider loginMemberProvider;
+    private final RouteService routeService;
+
+    @Transactional
+    public Long save(PollCreateRequest request) {
+        Member member = loginMemberProvider.getCurrentLoginMember();
+        Poll poll = Poll.toEntity(request, member);
+        pollRepository.save(poll);
+        return poll.getId();
+    }
+
+    @Transactional(readOnly = true)
+    public PollDetailResponse getPoll(Long pollId) {
+        Poll poll = findById(pollId);
+        int commentCount = getCommentCount(pollId);
+        List<RouteSummaryResponse> routeSummaries = poll.getRouteOptions().stream()
+            .map(route -> {
+                List<PlaceSummaryResponse> placeSummaries = route.getRoutePlaces().stream()
+                    .map(routePlace -> PlaceSummaryResponse.create(routePlace.getPlace()))
+                    .toList();
+                return RouteSummaryResponse.toDto(route, placeSummaries);
+            })
+            .toList();
+        return PollDetailResponse.toDto(poll, poll.getMember(), commentCount, routeSummaries);
+    }
+
+    @Transactional
+    public void registerCandidate(Long pollId, PollCandidateRegisterRequest request) {
+        Member member = loginMemberProvider.getCurrentLoginMember();
+        Poll poll = findById(pollId);
+        Route route = routeService.findById(request.getRouteId());
+        poll.registerRouteOption(route);
+    }
+
+    @Transactional
+    public Long update(Long pollId, PollUpdateRequest request) {
+        Member member = loginMemberProvider.getCurrentLoginMember();
+        Poll poll = findById(pollId);
+        poll.validateOwner(poll, member);
+        poll.update(request);
+        return poll.getId();
+    }
+
+    @Transactional
+    public Long delete(Long pollId) {
+        Member member = loginMemberProvider.getCurrentLoginMember();
+        Poll poll = findById(pollId);
+        poll.validateOwner(poll, member);
+        pollRepository.delete(poll);
+        return pollId;
+    }
+
+    private int getCommentCount(Long pollId) {
+        return pollRepository.countCommentsOfPoll(pollId);
+    }
+
+    public Poll findById(Long pollId) {
+        return pollRepository.findById(pollId)
+            .orElseThrow(() -> ShowingException.from(ErrorCode.POLL_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/saerok/showing/api/domain/route/entity/Route.java
+++ b/src/main/java/com/saerok/showing/api/domain/route/entity/Route.java
@@ -1,6 +1,7 @@
 package com.saerok.showing.api.domain.route.entity;
 
 import com.saerok.showing.api.domain.member.entity.Member;
+import com.saerok.showing.api.domain.poll.entity.Poll;
 import com.saerok.showing.api.domain.route.dto.request.RouteCreateRequest;
 import com.saerok.showing.api.domain.routePlace.entity.RoutePlace;
 import com.saerok.showing.api.global.entity.BaseEntity;
@@ -62,6 +63,10 @@ public class Route extends BaseEntity {
 
     @OneToMany(mappedBy = "route", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<RoutePlace> routePlaces = new ArrayList<>();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "poll_id")
+    private Poll poll;
 
     public static Route toEntity(Member member, RouteCreateRequest request) {
         return Route.builder()

--- a/src/main/java/com/saerok/showing/api/global/exception/ErrorCode.java
+++ b/src/main/java/com/saerok/showing/api/global/exception/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode {
     MEMBER_NOT_ADMIN(HttpStatus.FORBIDDEN, "관리자 권한이 필요합니다."),
     REVIEW_WRITER_MISMATCH(HttpStatus.FORBIDDEN, "리뷰 작성자가 아닙니다."),
     POST_WRITER_MISMATCH(HttpStatus.FORBIDDEN, "게시글 작성자가 아닙니다."),
+    POLL_MAKER_MISMATCH(HttpStatus.FORBIDDEN, "투표 게시자가 아닙니다."),
     COMMENT_WRITER_MISMATCH(HttpStatus.FORBIDDEN, "댓글 작성자가 아닙니다."),
     ROUTE_MAKER_MISMATCH(HttpStatus.FORBIDDEN, "요청한 여행코스에 대해 접근 권한이 없습니다."),
     NO_TEAM_LEADER_PERMISSION(HttpStatus.FORBIDDEN, "요청한 사항은 팀 리더만 가능합니다."),
@@ -48,6 +49,7 @@ public enum ErrorCode {
     BIRD_NOT_FOUND(HttpStatus.NOT_FOUND, "새를 찾을 수 없습니다."),
     PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "장소를 찾을 수 없습니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다."),
+    POLL_NOT_FOUND(HttpStatus.NOT_FOUND, "투표를 찾을 수 없습니다."),
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
     ROUTE_NOT_FOUND(HttpStatus.NOT_FOUND, "나만의 경로를 찾을 수 없습니다."),
     ROUTE_PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "여행코스 내 장소를 찾을 수 없습니다."),
@@ -63,6 +65,7 @@ public enum ErrorCode {
     // 409: CONFLICT (중복된 요청)
     DUPLICATE_RESOURCE(HttpStatus.CONFLICT, "이미 존재하는 리소스입니다."),
     DUPLICATE_MEMBER_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
+    DUPLICATE_ROUTE_REGISTERED_IN_POLL(HttpStatus.CONFLICT, "이미 해당 투표에 등록된 여행 후보지입니다."),
 
     // 500: INTERNAL SERVER ERROR (서버 내부 오류)
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 오류가 발생했습니다."),


### PR DESCRIPTION
## ⭐️ Overview

> #32 

투표(Poll) 기능을 구현 완료했습니다.

## 🔧 Tasks

- 투표 생성
- 투표 수정
- 투표 후보지 등록
- 투표 조회
- 투표 삭제

## 📝 Additional Notes

- 현재는 좋아요를 이용하여 투표 후보지를 선택합니다.
- 여행 후보지(Route) 등록은 한 번에 하나만 가능하고, 중복 등록을 방지했습니다.
- 기획 확정 후(투표 종료 조건, 팀 구성 등) 리팩토링 예정입니다.

## 📸 Screenshot

### 투표 API
<img width="700" alt="투표 API" src="https://github.com/user-attachments/assets/f11bcd10-8cc9-4130-9c5b-c2f3d96f94cf" />
