### PR TITLE
refactor: 테마 데이터 필드 및 구조 추가 작업 완료

### DIFF
--- a/src/main/java/com/saerok/showing/api/domain/theme/dto/response/DescriptionBlockResponse.java
+++ b/src/main/java/com/saerok/showing/api/domain/theme/dto/response/DescriptionBlockResponse.java
@@ -1,0 +1,21 @@
+package com.saerok.showing.api.domain.theme.dto.response;
+
+import com.saerok.showing.api.domain.theme.entity.DescriptionBlock;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DescriptionBlockResponse {
+
+    private String title;
+
+    private String description;
+
+    public static DescriptionBlockResponse toDto(DescriptionBlock descriptionBlock) {
+        return DescriptionBlockResponse.builder()
+            .title(descriptionBlock.getTitle())
+            .description(descriptionBlock.getDescription())
+            .build();
+    }
+}

--- a/src/main/java/com/saerok/showing/api/domain/theme/dto/response/ThemeDetailResponse.java
+++ b/src/main/java/com/saerok/showing/api/domain/theme/dto/response/ThemeDetailResponse.java
@@ -17,9 +17,15 @@ public class ThemeDetailResponse {
 
     private String title;
 
-    private String description;
-
     private String themeImage;
+
+    private String address;
+
+    private String locationIntro;
+
+    private List<String> highlightPoints;
+
+    private List<DescriptionBlockResponse> descriptionBlocks;
 
     private List<BirdSummaryResponse> birds;
 
@@ -42,7 +48,14 @@ public class ThemeDetailResponse {
         return ThemeDetailResponse.builder()
             .id(theme.getId())
             .title(theme.getTitle())
-            .description(theme.getDescription())
+            .address(theme.getAddress())
+            .locationIntro(theme.getLocationIntro())
+            .highlightPoints(theme.getHighlightPoints())
+            .descriptionBlocks(
+                theme.getDescriptionBlocks().stream()
+                    .map(DescriptionBlockResponse::toDto)
+                    .toList()
+            )
             .themeImage(theme.getThemeImage())
             .birds(birds)
             .attractionPlaces(attractionPlaces)

--- a/src/main/java/com/saerok/showing/api/domain/theme/entity/DescriptionBlock.java
+++ b/src/main/java/com/saerok/showing/api/domain/theme/entity/DescriptionBlock.java
@@ -1,0 +1,25 @@
+package com.saerok.showing.api.domain.theme.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Embeddable
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class DescriptionBlock {
+
+    @Column(name = "description_title", columnDefinition = "TEXT", nullable = false)
+    private String title;
+
+    @Column(name = "description", columnDefinition = "TEXT", nullable = false)
+    private String description;
+}

--- a/src/main/java/com/saerok/showing/api/domain/theme/entity/Theme.java
+++ b/src/main/java/com/saerok/showing/api/domain/theme/entity/Theme.java
@@ -12,6 +12,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OrderColumn;
 import jakarta.persistence.Table;
 import java.util.ArrayList;
 import java.util.List;
@@ -42,9 +43,6 @@ public class Theme extends BaseEntity implements Locatable {
     @Column(name = "origin_title", nullable = false)
     private String originTitle;
 
-    @Column(name = "description", nullable = false)
-    private String description;
-
     @ElementCollection
     @CollectionTable(
         name = "theme_season",
@@ -66,11 +64,34 @@ public class Theme extends BaseEntity implements Locatable {
     @Column(name = "theme_image")
     private String themeImage;
 
+    @Column(name = "address", nullable = false)
+    private String address;
+
     @Column(name = "location_x", nullable = false)
     private Double locationX;
 
     @Column(name = "location_y", nullable = false)
     private Double locationY;
+
+    @Column(name = "locationIntro", columnDefinition = "TEXT", nullable = false)
+    private String locationIntro;
+
+    @ElementCollection
+    @CollectionTable(
+        name = "theme_highlight_points",
+        joinColumns = @JoinColumn(name = "theme_id")
+    )
+    @OrderColumn(name = "list_order")
+    @Column(name = "highlight_point", columnDefinition = "TEXT")
+    private List<String> highlightPoints = new ArrayList<>();
+
+    @ElementCollection
+    @CollectionTable(
+        name = "theme_description_blocks",
+        joinColumns = @JoinColumn(name = "theme_id")
+    )
+    @OrderColumn(name = "list_order")
+    private List<DescriptionBlock> descriptionBlocks = new ArrayList<>();
 
     @Override
     public double getLocationX() {


### PR DESCRIPTION
## ⭐️ Overview

> #36

테마 상세 응답에 필요한 필드 및 구조 추가 작업을 완료했습니다.

## 🔧 Tasks

- Theme 엔티티에 highlightPoints, descriptionBlocks 필드 추가
- ThemeDetailResponse 응답 DTO에 필드 반영 및 매핑 로직 추가

## 📝 Additional Notes

- 설명 제목과 내용의 순서를 보장하기 위해 `@ElementCollection`과 `@OrderColumn`을 적용했습니다.
- 추후 기획 또는 기능 확장에 따라 구조 리팩토링 가능성이 있습니다.

## 📸 Screenshot

### 단건 테마 데이터 조회
<img width="1116" height="461" alt="테마 데이터 조회 사진" src="https://github.com/user-attachments/assets/2ec69675-651b-490e-9ad9-a0dd8c4e4b68" />
