### PR TITLE
refactor: 팀 가입 시 팀ID 대신 팀 이름 사용

### DIFF
--- a/src/main/java/com/saerok/showing/api/domain/team/controller/TeamController.java
+++ b/src/main/java/com/saerok/showing/api/domain/team/controller/TeamController.java
@@ -32,7 +32,9 @@ public class TeamController {
         description = """
             [모든 Role 가능] 새로운 팀을 생성합니다.<br>
             팀을 생성한 사람은 팀리더가 됩니다.<br>
-            이미 팀이 존재하는 회원은 팀 생성을 할 수 없습니다.
+            이미 팀이 존재하는 회원은 팀 생성을 할 수 없습니다.<br>
+            팀명은 2~30글자 이며 중복이 불가능합니다.<br>
+            팀 인증코드는 영문자와 숫자를 조합한 4~30글자입니다.
             """
     )
     @PreAuthorize("hasRole('MEMBER')")

--- a/src/main/java/com/saerok/showing/api/domain/team/dto/request/TeamJoinRequest.java
+++ b/src/main/java/com/saerok/showing/api/domain/team/dto/request/TeamJoinRequest.java
@@ -12,8 +12,8 @@ import lombok.Setter;
 public class TeamJoinRequest {
 
     @NotNull
-    @Schema(description = "가입할 팀 ID입니다.", example = "1")
-    private Long teamId;
+    @Schema(description = "가입할 팀명을 입력해주세요.", example = "금화초등학교")
+    private String name;
 
     @NotNull
     @Size(min = 4, max = 30)

--- a/src/main/java/com/saerok/showing/api/domain/team/entity/Team.java
+++ b/src/main/java/com/saerok/showing/api/domain/team/entity/Team.java
@@ -35,7 +35,7 @@ public class Team {
     @Column(name = "team_id")
     private Long id;
 
-    @Column(name = "name", nullable = false)
+    @Column(name = "name", nullable = false, unique = true)
     private String name;
 
     @Column(name = "password", nullable = false)

--- a/src/main/java/com/saerok/showing/api/domain/team/repository/TeamRepository.java
+++ b/src/main/java/com/saerok/showing/api/domain/team/repository/TeamRepository.java
@@ -12,4 +12,8 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
 
     @Query("SELECT t FROM Team t JOIN FETCH t.members WHERE t.id = :teamId")
     Optional<Team> findByIdWithMembers(@Param("teamId") Long teamId);
+
+    Optional<Team> findByName(String name);
+
+    boolean existsByName(String name);
 }

--- a/src/main/java/com/saerok/showing/api/domain/team/service/TeamService.java
+++ b/src/main/java/com/saerok/showing/api/domain/team/service/TeamService.java
@@ -43,7 +43,7 @@ public class TeamService {
     public Long joinTeam(TeamJoinRequest request) {
         Member member = loginMemberProvider.getCurrentLoginMember();
         validateNotAlreadyJoined(member);
-        Team team = findById(request.getTeamId());
+        Team team = findByName(request.getName());
         validateTeamPassword(team, request.getPassword());
         member.joinTeam(team);
         memberRepository.save(member);

--- a/src/main/java/com/saerok/showing/api/domain/team/service/TeamService.java
+++ b/src/main/java/com/saerok/showing/api/domain/team/service/TeamService.java
@@ -30,6 +30,7 @@ public class TeamService {
     public Long save(TeamCreateRequest request) {
         Member member = loginMemberProvider.getCurrentLoginMember();
         validateNotAlreadyJoined(member);
+        validateUniqueTeamName(request.getName());
         String encodedPassword = passwordEncoder.encode(request.getPassword());
         Team team = Team.toEntity(request, member, encodedPassword);
         teamRepository.save(team);
@@ -88,6 +89,11 @@ public class TeamService {
             .orElseThrow(() -> ShowingException.from(ErrorCode.TEAM_NOT_FOUND));
     }
 
+    private Team findByName(String name) {
+        return teamRepository.findByName(name)
+            .orElseThrow(() -> ShowingException.from(ErrorCode.TEAM_NOT_FOUND));
+    }
+
     private Team getTeamOfCurrentMember() {
         Member currentMember = loginMemberProvider.getCurrentLoginMember();
         if (currentMember.getTeam() == null) {
@@ -95,6 +101,12 @@ public class TeamService {
         }
         return teamRepository.findByIdWithMembers(currentMember.getTeam().getId())
             .orElseThrow(() -> ShowingException.from(ErrorCode.TEAM_NOT_FOUND));
+    }
+
+    private void validateUniqueTeamName(String name) {
+        if (teamRepository.existsByName(name)) {
+            throw ShowingException.from(ErrorCode.DUPLICATE_TEAM_NAME);
+        }
     }
 
     private void validateNotAlreadyJoined(Member member) {

--- a/src/main/java/com/saerok/showing/api/global/exception/ErrorCode.java
+++ b/src/main/java/com/saerok/showing/api/global/exception/ErrorCode.java
@@ -65,6 +65,7 @@ public enum ErrorCode {
     // 409: CONFLICT (중복된 요청)
     DUPLICATE_RESOURCE(HttpStatus.CONFLICT, "이미 존재하는 리소스입니다."),
     DUPLICATE_MEMBER_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
+    DUPLICATE_TEAM_NAME(HttpStatus.CONFLICT, "이미 사용 중인 팀명입니다."),
     DUPLICATE_ROUTE_REGISTERED_IN_POLL(HttpStatus.CONFLICT, "이미 해당 투표에 등록된 여행 후보지입니다."),
 
     // 500: INTERNAL SERVER ERROR (서버 내부 오류)


### PR DESCRIPTION
## ⭐️ Overview

> #39

팀 가입 시 `teamId` 대신 팀 이름(`name`) 으로 가입하도록 수정했습니다.

## 🔧 Tasks

- 팀 엔티티 `name` 필드 유니크 제약조건
- 팀 가입 시 `teamId` → `name`으로 변경
- 팀명 중복 시 예외 처리

## 📝 Additional Notes

- 팀 이름은 중복이 불가능합니다.
- 팀명은 2~30글자입니다.
- 팀 입장 암호는 영문자, 숫자 조합으로 4~30글자입니다.
