### PR TITLE
feat: 커서 기반 페이지네이션 구현 완료

### DIFF
--- a/src/main/java/com/saerok/showing/api/global/pagination/cursorResult/CreatedAtCursorResult.java
+++ b/src/main/java/com/saerok/showing/api/global/pagination/cursorResult/CreatedAtCursorResult.java
@@ -1,0 +1,33 @@
+package com.saerok.showing.api.global.pagination.cursorResult;
+
+import com.saerok.showing.api.global.pagination.provider.CreatedAtProvider;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public record CreatedAtCursorResult<T extends CreatedAtProvider>(
+    List<T> values,
+    boolean hasPrevious,
+    boolean hasNext
+) {
+
+    public static <T extends CreatedAtProvider> CreatedAtCursorResult<T> of(
+        List<T> values, LocalDateTime cursor, int limit
+    ) {
+        boolean hasPrevious = checkFirstPageByCreatedAt(cursor, values);
+
+        boolean hasNext = values.size() > limit;
+        List<T> trimmedValues = hasNext ? values.subList(0, limit) : values;
+
+        return new CreatedAtCursorResult<>(trimmedValues, hasPrevious, hasNext);
+    }
+
+    private static <T extends CreatedAtProvider> boolean checkFirstPageByCreatedAt(
+        LocalDateTime cursor, List<T> values
+    ) {
+        return cursor != null
+            && !values.isEmpty()
+            && values.getFirst().getCreatedAt().isAfter(cursor);
+    }
+}

--- a/src/main/java/com/saerok/showing/api/global/pagination/cursorResult/IdCursorResult.java
+++ b/src/main/java/com/saerok/showing/api/global/pagination/cursorResult/IdCursorResult.java
@@ -1,0 +1,28 @@
+package com.saerok.showing.api.global.pagination.cursorResult;
+
+import com.saerok.showing.api.global.pagination.provider.IdProvider;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public record IdCursorResult<T extends IdProvider>(
+    List<T> values,
+    boolean hasPrevious,
+    boolean hasNext
+) {
+    public static <T extends IdProvider> IdCursorResult<T> of(List<T> values, Long cursor, int limit) {
+        boolean hasPrevious = checkFirstPageById(cursor, values);
+
+        boolean hasNext = values.size() > limit;
+        List<T> trimmedValues = hasNext ? values.subList(0, limit) : values;
+
+        return new IdCursorResult<>(trimmedValues, hasPrevious, hasNext);
+    }
+
+    private static <T extends IdProvider> boolean checkFirstPageById(Long cursor, List<T> values) {
+        return cursor != null
+            && cursor > 0
+            && !values.isEmpty()
+            && values.getFirst().getId() > cursor;
+    }
+}

--- a/src/main/java/com/saerok/showing/api/global/pagination/provider/CreatedAtProvider.java
+++ b/src/main/java/com/saerok/showing/api/global/pagination/provider/CreatedAtProvider.java
@@ -1,0 +1,8 @@
+package com.saerok.showing.api.global.pagination.provider;
+
+import java.time.LocalDateTime;
+
+public interface CreatedAtProvider {
+
+    LocalDateTime getCreatedAt();
+}

--- a/src/main/java/com/saerok/showing/api/global/pagination/provider/IdProvider.java
+++ b/src/main/java/com/saerok/showing/api/global/pagination/provider/IdProvider.java
@@ -1,0 +1,6 @@
+package com.saerok.showing.api.global.pagination.provider;
+
+public interface IdProvider {
+
+    Long getId();
+}


### PR DESCRIPTION
## ⭐️ Overview

> #41

커서 기반 페이지네이션 구현 완료했습니다.

## 🔧 Tasks

- 커서 기반 페이지네이션 로직 도입
- `IdProvider`, `CreatedAtProvider` 인터페이스 분리 및 적용

## 📌 설계 의도

- record 클래스를 사용해 커서 결과 객체의 불변성과 가독성을 높였습니다.
- `IdProvider`, `CreatedAtProvider` 인터페이스 기반으로 제네릭 커서 결과 객체를 생성합니다.
- 커서 기준 필드는 `id`, `createdAt` 등으로 확장 가능하며, 인터페이스를 작고 명확하게 나누어 변경에 강한 구조를 만들었습니다. (ISP 패턴 준수)
- 페이징 응답은 다음과 같은 형태로 제공됩니다:
```
{
  "values": [...],
  "hasPrevious": true,
  "hasNext": true
}
```

## 📝 Additional Notes

- 커서 기반 요청 시, 초기 요청에는 `cursor`를 생략하고 이후 페이지 요청부터 마지막 항목의 `id` 또는 `createdAt` 값을 `cursor`로 전달하면 됩니다.
- 응답의 `hasNext` 값이 `true`일 경우 → 추가 데이터를 로딩할 수 있습니다.
- `values` 배열의 마지막 요소의 커서 필드를 다음 요청의 `cursor` 값으로 사용하면 됩니다.

