### PR TITLE
refactor: 게시글 커서 기반 페이지네이션 전략 구현 및 적용 완료

### DIFF
--- a/src/main/java/com/saerok/showing/api/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/saerok/showing/api/domain/comment/repository/CommentRepository.java
@@ -10,4 +10,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findAllByPostId(Long postId);
 
     Optional<Comment> findByIdAndPostId(Long commentId, Long postId);
+
+    int countByPostId(Long postId);
 }

--- a/src/main/java/com/saerok/showing/api/domain/comment/service/CommentCountProvider.java
+++ b/src/main/java/com/saerok/showing/api/domain/comment/service/CommentCountProvider.java
@@ -1,0 +1,6 @@
+package com.saerok.showing.api.domain.comment.service;
+
+public interface CommentCountProvider {
+
+    int getCount(Long postId);
+}

--- a/src/main/java/com/saerok/showing/api/domain/comment/service/CommentCountProviderImpl.java
+++ b/src/main/java/com/saerok/showing/api/domain/comment/service/CommentCountProviderImpl.java
@@ -1,0 +1,17 @@
+package com.saerok.showing.api.domain.comment.service;
+
+import com.saerok.showing.api.domain.comment.repository.CommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CommentCountProviderImpl implements CommentCountProvider {
+
+    private final CommentRepository commentRepository;
+
+    @Override
+    public int getCount(Long postId) {
+        return commentRepository.countByPostId(postId);
+    }
+}

--- a/src/main/java/com/saerok/showing/api/domain/post/controller/PostController.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/controller/PostController.java
@@ -7,11 +7,11 @@ import com.saerok.showing.api.domain.post.dto.response.PostSummaryResponse;
 import com.saerok.showing.api.domain.post.entity.PostSortType;
 import com.saerok.showing.api.domain.post.entity.PostType;
 import com.saerok.showing.api.domain.post.service.PostService;
+import com.saerok.showing.api.global.pagination.cursorResult.CursorResult;
 import com.saerok.showing.api.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -55,10 +55,10 @@ public class PostController {
     )
     @PreAuthorize("hasRole('MEMBER')")
     @GetMapping("/{postId}")
-    public ApiResponse<PostDetailResponse> getPost(
+    public ApiResponse<PostDetailResponse> getPostDetails(
         @PathVariable(name = "postId") Long postId
     ) {
-        PostDetailResponse response = postService.getPost(postId);
+        PostDetailResponse response = postService.getPostDetails(postId);
         return ApiResponse.success(response);
     }
 
@@ -67,17 +67,26 @@ public class PostController {
         description = """
             [모든 Role 가능] 게시글 타입에 따른 카테고리별 게시글을 조회합니다.<br>
             - 게시글 타입: 일반(NORMAL), 투표(POLL), 여행계획(ROUTE)<br>
-            - `postType` 파라미터를 생략하면 전체 게시글이 조회됩니다.
+            - `postType`을 생략하면 전체 게시글이 조회됩니다.<br>
+            - 정렬 타입: 최신순(LATEST), 인기순(POPULAR)<br>
+            - `sort`을 생략하면 최신순으로 정렬됩니다.<br>
+            
+            📌 커서 기반 페이지네이션 안내<br>
+            - `cursorRaw` : 마지막으로 조회된 게시글의 `createdAt` 값입니다. 이후의 데이터를 조회할 때 사용됩니다.<br>
+            - `limit` : 한 번에 가져올 데이터 수입니다. 기본값은 4이며, 무한 스크롤에 사용됩니다.<br>
+            - 응답에는 다음 페이지 존재 여부(`hasNext`) 및 이전 페이지 존재 여부(`hasPrevious`)가 함께 포함됩니다.
             """
     )
     @PreAuthorize("hasRole('MEMBER')")
     @GetMapping("/list")
-    public ApiResponse<List<PostSummaryResponse>> getAllPosts(
+    public ApiResponse<CursorResult<PostSummaryResponse>> getPosts(
         @RequestParam(name = "postType", required = false) PostType postType,
-        @RequestParam(name = "sort", required = false, defaultValue = "LATEST") PostSortType sortType
+        @RequestParam(name = "sort", required = false, defaultValue = "LATEST") PostSortType sortType,
+        @RequestParam(name = "cursor", required = false) String cursorRaw,
+        @RequestParam(name = "limit", defaultValue = "4") int limit
     ) {
-        List<PostSummaryResponse> response = postService.getAllPosts(postType, sortType);
-        return ApiResponse.success(response);
+        CursorResult<PostSummaryResponse> result = postService.getPosts(postType, sortType, cursorRaw, limit);
+        return ApiResponse.success(result);
     }
 
     @Operation(

--- a/src/main/java/com/saerok/showing/api/domain/post/dto/response/PostSummaryResponse.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/dto/response/PostSummaryResponse.java
@@ -1,20 +1,19 @@
 package com.saerok.showing.api.domain.post.dto.response;
 
-import com.saerok.showing.api.domain.member.entity.Member;
 import com.saerok.showing.api.domain.post.entity.Post;
 import com.saerok.showing.api.domain.post.entity.PostType;
 import com.saerok.showing.api.global.file.dto.ExternalFileResponse;
 import com.saerok.showing.api.global.file.entity.UploadedFile;
 import com.saerok.showing.api.global.pagination.provider.CreatedAtProvider;
+import com.saerok.showing.api.global.pagination.provider.PopularProvider;
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
-public class PostSummaryResponse implements CreatedAtProvider {
+public class PostSummaryResponse implements CreatedAtProvider, PopularProvider {
 
     private Long id;
 
@@ -35,6 +34,16 @@ public class PostSummaryResponse implements CreatedAtProvider {
     private int commentCount;
 
     private LocalDateTime createdAt;
+
+    @Override
+    public int getLikeCount() {
+        return likeCount;
+    }
+
+    @Override
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
 
     public static PostSummaryResponse toDto(Post post, int commentCount) {
         Optional<UploadedFile> firstFile = post.getPostImages().stream().findFirst();

--- a/src/main/java/com/saerok/showing/api/domain/post/dto/response/PostSummaryResponse.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/dto/response/PostSummaryResponse.java
@@ -5,14 +5,16 @@ import com.saerok.showing.api.domain.post.entity.Post;
 import com.saerok.showing.api.domain.post.entity.PostType;
 import com.saerok.showing.api.global.file.dto.ExternalFileResponse;
 import com.saerok.showing.api.global.file.entity.UploadedFile;
+import com.saerok.showing.api.global.pagination.provider.CreatedAtProvider;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
-public class PostSummaryResponse {
+public class PostSummaryResponse implements CreatedAtProvider {
 
     private Long id;
 
@@ -24,7 +26,7 @@ public class PostSummaryResponse {
 
     private String content;
 
-    private List<ExternalFileResponse> postImages;
+    private ExternalFileResponse postImage;
 
     private PostType postType;
 
@@ -32,18 +34,25 @@ public class PostSummaryResponse {
 
     private int commentCount;
 
+    private LocalDateTime createdAt;
+
     public static PostSummaryResponse toDto(Post post, int commentCount) {
-        List<UploadedFile> files = post.getPostImages();
+        Optional<UploadedFile> firstFile = post.getPostImages().stream().findFirst();
+        ExternalFileResponse imageDto = firstFile
+            .map(ExternalFileResponse::toDto)
+            .orElse(null);
+
         return PostSummaryResponse.builder()
             .id(post.getId())
             .title(post.getTitle())
             .writer(post.getMember().getName())
             .writerProfileImage(post.getMember().getProfileImage())
             .content(post.getContent())
-            .postImages(ExternalFileResponse.toListDto(files))
+            .postImage(imageDto)
             .postType(post.getPostType())
             .likeCount(post.getLikeCount())
             .commentCount(commentCount)
+            .createdAt(post.getCreatedAt())
             .build();
     }
 }

--- a/src/main/java/com/saerok/showing/api/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/repository/PostRepository.java
@@ -2,6 +2,7 @@ package com.saerok.showing.api.domain.post.repository;
 
 import com.saerok.showing.api.domain.post.entity.Post;
 import com.saerok.showing.api.domain.post.entity.PostType;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -11,16 +12,53 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-    @Query("SELECT COUNT(c) FROM Comment c WHERE c.post.id = :postId")
-    int countCommentsOfPost(@Param("postId") Long postId);
+    // 1. 커서가 없을 때 (최초 요청) - 최신순
+    @Query("""
+            SELECT p FROM Post p
+            WHERE (:postType IS NULL OR p.postType = :postType)
+            ORDER BY p.createdAt DESC
+        """)
+    List<Post> findByPostTypeOrderByCreatedAtDesc(
+        @Param("postType") PostType postType
+    );
 
-    // 인기순
-    List<Post> findByPostTypeOrderByLikeCountDesc(PostType postType);
-    List<Post> findAllByOrderByLikeCountDesc();
+    // 2. 커서가 있을 때 (이후 페이지 요청) - 최신순
+    @Query("""
+            SELECT p FROM Post p
+            WHERE (:postType IS NULL OR p.postType = :postType)
+              AND p.createdAt < :cursor
+            ORDER BY p.createdAt DESC
+        """)
+    List<Post> findByPostTypeAndCreatedAtBeforeOrderByCreatedAtDesc(
+        @Param("postType") PostType postType,
+        @Param("cursor") LocalDateTime cursor
+    );
 
-    // 최신순
-    List<Post> findByPostTypeOrderByCreatedAtDesc(PostType postType);
-    List<Post> findAllByOrderByCreatedAtDesc();
+    // 1. 커서가 없을 때 (인기순 기본 정렬) - 인기순
+    @Query("""
+            SELECT p FROM Post p
+            WHERE (:postType IS NULL OR p.postType = :postType)
+            ORDER BY p.likeCount DESC, p.createdAt DESC
+        """)
+    List<Post> findByPostTypeOrderByLikeCountDesc(
+        @Param("postType") PostType postType
+    );
+
+    // 2. 커서가 있을 때 (likeCount, createdAt 기준 페이징) - 인기순
+    @Query("""
+            SELECT p FROM Post p
+            WHERE (:postType IS NULL OR p.postType = :postType)
+              AND (
+                p.likeCount < :likeCount
+                OR (p.likeCount = :likeCount AND p.createdAt < :createdAt)
+              )
+            ORDER BY p.likeCount DESC, p.createdAt DESC
+        """)
+    List<Post> findByPopularCursor(
+        @Param("postType") PostType postType,
+        @Param("likeCount") int likeCount,
+        @Param("createdAt") LocalDateTime createdAt
+    );
 
     int countByMemberId(Long memberId);
 }

--- a/src/main/java/com/saerok/showing/api/domain/post/service/PostService.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/service/PostService.java
@@ -1,5 +1,6 @@
 package com.saerok.showing.api.domain.post.service;
 
+import com.saerok.showing.api.domain.comment.service.CommentCountProvider;
 import com.saerok.showing.api.domain.member.entity.Member;
 import com.saerok.showing.api.domain.post.dto.request.PostCreateRequest;
 import com.saerok.showing.api.domain.post.dto.request.PostUpdateRequest;
@@ -9,13 +10,15 @@ import com.saerok.showing.api.domain.post.entity.Post;
 import com.saerok.showing.api.domain.post.entity.PostSortType;
 import com.saerok.showing.api.domain.post.entity.PostType;
 import com.saerok.showing.api.domain.post.repository.PostRepository;
+import com.saerok.showing.api.domain.post.service.pagination.PostPaginationStrategy;
+import com.saerok.showing.api.domain.post.service.pagination.PostPaginationStrategyFactory;
 import com.saerok.showing.api.global.auth.util.LoginMemberProvider;
 import com.saerok.showing.api.global.exception.ErrorCode;
 import com.saerok.showing.api.global.exception.ShowingException;
 import com.saerok.showing.api.global.file.entity.UploadedFile;
 import com.saerok.showing.api.global.file.service.FileService;
+import com.saerok.showing.api.global.pagination.cursorResult.CursorResult;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,6 +30,8 @@ public class PostService {
     private final PostRepository postRepository;
     private final LoginMemberProvider loginMemberProvider;
     private final FileService fileService;
+    private final PostPaginationStrategyFactory postPaginationStrategyFactory;
+    private final CommentCountProvider commentCountProvider;
 
     @Transactional
     public Long save(PostCreateRequest request) {
@@ -38,18 +43,21 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public PostDetailResponse getPost(Long postId) {
+    public PostDetailResponse getPostDetails(Long postId) {
         Post post = findById(postId);
-        int commentCount = getCommentCount(postId);
+        int commentCount = commentCountProvider.getCount(postId);
         return PostDetailResponse.toDto(post, commentCount);
     }
 
     @Transactional(readOnly = true)
-    public List<PostSummaryResponse> getAllPosts(PostType postType, PostSortType sortType) {
-        List<Post> posts = getPostsByTypeAndSort(postType, sortType);
-        return posts.stream()
-            .map(post -> PostSummaryResponse.toDto(post, getCommentCount(post.getId())))
-            .collect(Collectors.toList());
+    public CursorResult<PostSummaryResponse> getPosts(
+        PostType postType,
+        PostSortType sortType,
+        String cursorRaw,
+        int limit
+    ) {
+        PostPaginationStrategy strategy = postPaginationStrategyFactory.getStrategy(sortType);
+        return strategy.getCursorResult(postType, cursorRaw, limit, commentCountProvider);
     }
 
     @Transactional
@@ -73,22 +81,6 @@ public class PostService {
     public int getPostCount() {
         Long memberId = loginMemberProvider.getCurrentLoginMemberId();
         return postRepository.countByMemberId(memberId);
-    }
-
-    private int getCommentCount(Long postId) {
-        return postRepository.countCommentsOfPost(postId);
-    }
-
-    private List<Post> getPostsByTypeAndSort(PostType postType, PostSortType sortType) {
-        boolean isPopular = sortType == PostSortType.POPULAR;
-        if (postType == null) {
-            return isPopular
-                ? postRepository.findAllByOrderByLikeCountDesc()
-                : postRepository.findAllByOrderByCreatedAtDesc();
-        }
-        return isPopular
-            ? postRepository.findByPostTypeOrderByLikeCountDesc(postType)
-            : postRepository.findByPostTypeOrderByCreatedAtDesc(postType);
     }
 
     public Post findById(Long postId) {

--- a/src/main/java/com/saerok/showing/api/domain/post/service/pagination/LatestPostPaginationStrategy.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/service/pagination/LatestPostPaginationStrategy.java
@@ -1,0 +1,67 @@
+package com.saerok.showing.api.domain.post.service.pagination;
+
+import com.saerok.showing.api.domain.comment.service.CommentCountProvider;
+import com.saerok.showing.api.domain.post.dto.response.PostSummaryResponse;
+import com.saerok.showing.api.domain.post.entity.Post;
+import com.saerok.showing.api.domain.post.entity.PostSortType;
+import com.saerok.showing.api.domain.post.entity.PostType;
+import com.saerok.showing.api.domain.post.repository.PostRepository;
+import com.saerok.showing.api.global.exception.ErrorCode;
+import com.saerok.showing.api.global.exception.ShowingException;
+import com.saerok.showing.api.global.pagination.cursor.CreatedAtCursor;
+import com.saerok.showing.api.global.pagination.cursorResult.CreatedAtCursorResult;
+import com.saerok.showing.api.global.pagination.cursorResult.CursorResult;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LatestPostPaginationStrategy implements PostPaginationStrategy {
+
+    private final PostRepository postRepository;
+
+    @Override
+    public PostSortType getSortType() {
+        return PostSortType.LATEST;
+    }
+
+    @Override
+    public Object parseCursor(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return null;
+        }
+        try {
+            return new CreatedAtCursor(LocalDateTime.parse(raw));
+        } catch (Exception e) {
+            throw ShowingException.from(ErrorCode.INVALID_CURSOR_FORMAT);
+        }
+    }
+
+    @Override
+    public List<Post> paginate(PostType postType, Object cursor, int limit) {
+        LocalDateTime cursorTime = (cursor instanceof CreatedAtCursor c) ? c.createdAt() : null;
+        return (
+            cursorTime == null
+                ? postRepository.findByPostTypeOrderByCreatedAtDesc(postType)
+                : postRepository.findByPostTypeAndCreatedAtBeforeOrderByCreatedAtDesc(postType, cursorTime)
+        ).stream()
+            .limit(limit + 1)
+            .toList();
+    }
+
+    public CursorResult<PostSummaryResponse> getCursorResult(
+        PostType postType,
+        String cursorRaw,
+        int limit,
+        CommentCountProvider commentCountProvider
+    ) {
+        CreatedAtCursor cursor = (CreatedAtCursor) parseCursor(cursorRaw);
+        List<Post> posts = paginate(postType, cursor, limit);
+        List<PostSummaryResponse> responses = posts.stream()
+            .map(post -> PostSummaryResponse.toDto(post, commentCountProvider.getCount(post.getId())))
+            .toList();
+        return CreatedAtCursorResult.of(responses, cursor, limit);
+    }
+}

--- a/src/main/java/com/saerok/showing/api/domain/post/service/pagination/PopularPostPaginationStrategy.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/service/pagination/PopularPostPaginationStrategy.java
@@ -1,0 +1,71 @@
+package com.saerok.showing.api.domain.post.service.pagination;
+
+import com.saerok.showing.api.domain.comment.service.CommentCountProvider;
+import com.saerok.showing.api.domain.post.dto.response.PostSummaryResponse;
+import com.saerok.showing.api.domain.post.entity.Post;
+import com.saerok.showing.api.domain.post.entity.PostSortType;
+import com.saerok.showing.api.domain.post.entity.PostType;
+import com.saerok.showing.api.domain.post.repository.PostRepository;
+import com.saerok.showing.api.global.exception.ErrorCode;
+import com.saerok.showing.api.global.exception.ShowingException;
+import com.saerok.showing.api.global.pagination.cursor.PopularCursor;
+import com.saerok.showing.api.global.pagination.cursorResult.CursorResult;
+import com.saerok.showing.api.global.pagination.cursorResult.PopularCursorResult;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PopularPostPaginationStrategy implements PostPaginationStrategy {
+
+    private final PostRepository postRepository;
+
+    @Override
+    public PostSortType getSortType() {
+        return PostSortType.POPULAR;
+    }
+
+    @Override
+    public Object parseCursor(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return null;
+        }
+        try {
+            String[] parts = raw.split("\\|");
+            int likeCount = Integer.parseInt(parts[0]);
+            LocalDateTime createdAt = LocalDateTime.parse(parts[1]);
+            return new PopularCursor(likeCount, createdAt);
+        } catch (Exception e) {
+            throw ShowingException.from(ErrorCode.INVALID_CURSOR_FORMAT);
+        }
+    }
+
+    @Override
+    public List<Post> paginate(PostType postType, Object cursor, int limit) {
+        if (cursor instanceof PopularCursor c) {
+            return postRepository.findByPopularCursor(postType, c.likeCount(), c.createdAt()).stream()
+                .limit(limit + 1)
+                .toList();
+        }
+        return postRepository.findByPostTypeOrderByLikeCountDesc(postType).stream()
+            .limit(limit + 1)
+            .toList();
+    }
+
+    @Override
+    public CursorResult<PostSummaryResponse> getCursorResult(
+        PostType postType,
+        String cursorRaw,
+        int limit,
+        CommentCountProvider commentCountProvider
+    ) {
+        PopularCursor cursor = (PopularCursor) parseCursor(cursorRaw);
+        List<Post> posts = paginate(postType, cursor, limit);
+        List<PostSummaryResponse> responses = posts.stream()
+            .map(post -> PostSummaryResponse.toDto(post, commentCountProvider.getCount(post.getId())))
+            .toList();
+        return PopularCursorResult.of(responses, cursor, limit);
+    }
+}

--- a/src/main/java/com/saerok/showing/api/domain/post/service/pagination/PostPaginationStrategy.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/service/pagination/PostPaginationStrategy.java
@@ -1,0 +1,25 @@
+package com.saerok.showing.api.domain.post.service.pagination;
+
+import com.saerok.showing.api.domain.comment.service.CommentCountProvider;
+import com.saerok.showing.api.domain.post.dto.response.PostSummaryResponse;
+import com.saerok.showing.api.domain.post.entity.Post;
+import com.saerok.showing.api.domain.post.entity.PostSortType;
+import com.saerok.showing.api.domain.post.entity.PostType;
+import com.saerok.showing.api.global.pagination.cursorResult.CursorResult;
+import java.util.List;
+
+public interface PostPaginationStrategy {
+
+    PostSortType getSortType();
+
+    Object parseCursor(String rawCursor);
+
+    List<Post> paginate(PostType postType, Object cursor, int limit);
+
+    CursorResult<PostSummaryResponse> getCursorResult(
+        PostType postType,
+        String rawCursor,
+        int limit,
+        CommentCountProvider commentCountProvider
+    );
+}

--- a/src/main/java/com/saerok/showing/api/domain/post/service/pagination/PostPaginationStrategyFactory.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/service/pagination/PostPaginationStrategyFactory.java
@@ -1,0 +1,22 @@
+package com.saerok.showing.api.domain.post.service.pagination;
+
+import com.saerok.showing.api.domain.post.entity.PostSortType;
+import com.saerok.showing.api.global.exception.ErrorCode;
+import com.saerok.showing.api.global.exception.ShowingException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PostPaginationStrategyFactory {
+
+    private final List<PostPaginationStrategy> strategies;
+
+    public PostPaginationStrategy getStrategy(PostSortType sortType) {
+        return strategies.stream()
+            .filter(s -> s.getSortType() == sortType)
+            .findFirst()
+            .orElseThrow(() -> ShowingException.from(ErrorCode.UNSUPPORTED_SORT_TYPE));
+    }
+}

--- a/src/main/java/com/saerok/showing/api/global/exception/ErrorCode.java
+++ b/src/main/java/com/saerok/showing/api/global/exception/ErrorCode.java
@@ -15,6 +15,8 @@ public enum ErrorCode {
     UNSUPPORTED_OAUTH2_PROVIDER(HttpStatus.BAD_REQUEST, "지원하지 않는 OAuth2 제공자입니다."),
     INVALID_SOCIAL_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 소셜 로그인 타입입니다."),
     INVALID_LIKE_TARGET_TYPE(HttpStatus.BAD_REQUEST, "올바르지 않은 좋아요 대상 타입입니다."),
+    UNSUPPORTED_SORT_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 정렬 방식입니다."),
+    INVALID_CURSOR_FORMAT(HttpStatus.BAD_REQUEST, "커서 형식이 잘못되었습니다."),
 
     // 401: UNAUTHORIZED (인증 실패)
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),

--- a/src/main/java/com/saerok/showing/api/global/pagination/cursor/CreatedAtCursor.java
+++ b/src/main/java/com/saerok/showing/api/global/pagination/cursor/CreatedAtCursor.java
@@ -1,0 +1,7 @@
+package com.saerok.showing.api.global.pagination.cursor;
+
+import java.time.LocalDateTime;
+
+public record CreatedAtCursor(
+    LocalDateTime createdAt
+) {}

--- a/src/main/java/com/saerok/showing/api/global/pagination/cursor/IdCursor.java
+++ b/src/main/java/com/saerok/showing/api/global/pagination/cursor/IdCursor.java
@@ -1,0 +1,5 @@
+package com.saerok.showing.api.global.pagination.cursor;
+
+public record IdCursor(
+    Long id
+) {}

--- a/src/main/java/com/saerok/showing/api/global/pagination/cursor/PopularCursor.java
+++ b/src/main/java/com/saerok/showing/api/global/pagination/cursor/PopularCursor.java
@@ -1,0 +1,8 @@
+package com.saerok.showing.api.global.pagination.cursor;
+
+import java.time.LocalDateTime;
+
+public record PopularCursor(
+    int likeCount,
+    LocalDateTime createdAt
+) {}

--- a/src/main/java/com/saerok/showing/api/global/pagination/cursorResult/CreatedAtCursorResult.java
+++ b/src/main/java/com/saerok/showing/api/global/pagination/cursorResult/CreatedAtCursorResult.java
@@ -1,33 +1,33 @@
 package com.saerok.showing.api.global.pagination.cursorResult;
 
+import com.saerok.showing.api.global.pagination.cursor.CreatedAtCursor;
 import com.saerok.showing.api.global.pagination.provider.CreatedAtProvider;
-import java.time.LocalDateTime;
 import java.util.List;
-import lombok.Getter;
 
-@Getter
 public record CreatedAtCursorResult<T extends CreatedAtProvider>(
     List<T> values,
     boolean hasPrevious,
     boolean hasNext
-) {
+) implements CursorResult<T> {
 
     public static <T extends CreatedAtProvider> CreatedAtCursorResult<T> of(
-        List<T> values, LocalDateTime cursor, int limit
+        List<T> values,
+        CreatedAtCursor cursor,
+        int limit
     ) {
         boolean hasPrevious = checkFirstPageByCreatedAt(cursor, values);
-
         boolean hasNext = values.size() > limit;
         List<T> trimmedValues = hasNext ? values.subList(0, limit) : values;
-
         return new CreatedAtCursorResult<>(trimmedValues, hasPrevious, hasNext);
     }
 
     private static <T extends CreatedAtProvider> boolean checkFirstPageByCreatedAt(
-        LocalDateTime cursor, List<T> values
+        CreatedAtCursor cursor,
+        List<T> values
     ) {
-        return cursor != null
-            && !values.isEmpty()
-            && values.getFirst().getCreatedAt().isAfter(cursor);
+        if (cursor == null || values.isEmpty()) {
+            return false;
+        }
+        return values.getFirst().getCreatedAt().isAfter(cursor.createdAt());
     }
 }

--- a/src/main/java/com/saerok/showing/api/global/pagination/cursorResult/CursorResult.java
+++ b/src/main/java/com/saerok/showing/api/global/pagination/cursorResult/CursorResult.java
@@ -1,0 +1,12 @@
+package com.saerok.showing.api.global.pagination.cursorResult;
+
+import java.util.List;
+
+public interface CursorResult<T> {
+
+    List<T> values();
+
+    boolean hasPrevious();
+
+    boolean hasNext();
+}

--- a/src/main/java/com/saerok/showing/api/global/pagination/cursorResult/IdCursorResult.java
+++ b/src/main/java/com/saerok/showing/api/global/pagination/cursorResult/IdCursorResult.java
@@ -1,28 +1,34 @@
 package com.saerok.showing.api.global.pagination.cursorResult;
 
+import com.saerok.showing.api.global.pagination.cursor.IdCursor;
 import com.saerok.showing.api.global.pagination.provider.IdProvider;
-import java.util.List;
-import lombok.Getter;
 
-@Getter
+import java.util.List;
+
 public record IdCursorResult<T extends IdProvider>(
     List<T> values,
     boolean hasPrevious,
     boolean hasNext
-) {
-    public static <T extends IdProvider> IdCursorResult<T> of(List<T> values, Long cursor, int limit) {
-        boolean hasPrevious = checkFirstPageById(cursor, values);
+) implements CursorResult<T> {
 
+    public static <T extends IdProvider> IdCursorResult<T> of(
+        List<T> values,
+        IdCursor cursor,
+        int limit
+    ) {
+        boolean hasPrevious = checkFirstPageById(cursor, values);
         boolean hasNext = values.size() > limit;
         List<T> trimmedValues = hasNext ? values.subList(0, limit) : values;
-
         return new IdCursorResult<>(trimmedValues, hasPrevious, hasNext);
     }
 
-    private static <T extends IdProvider> boolean checkFirstPageById(Long cursor, List<T> values) {
-        return cursor != null
-            && cursor > 0
-            && !values.isEmpty()
-            && values.getFirst().getId() > cursor;
+    private static <T extends IdProvider> boolean checkFirstPageById(
+        IdCursor cursor,
+        List<T> values
+    ) {
+        if (cursor == null || values.isEmpty()) {
+            return false;
+        }
+        return values.getFirst().getId() > cursor.id();
     }
 }

--- a/src/main/java/com/saerok/showing/api/global/pagination/cursorResult/PopularCursorResult.java
+++ b/src/main/java/com/saerok/showing/api/global/pagination/cursorResult/PopularCursorResult.java
@@ -1,0 +1,33 @@
+package com.saerok.showing.api.global.pagination.cursorResult;
+
+import com.saerok.showing.api.global.pagination.cursor.PopularCursor;
+import com.saerok.showing.api.global.pagination.provider.PopularProvider;
+import java.util.List;
+
+public record PopularCursorResult<T extends PopularProvider>(
+    List<T> values,
+    boolean hasPrevious,
+    boolean hasNext
+) implements CursorResult<T> {
+
+    public static <T extends PopularProvider> PopularCursorResult<T> of(
+        List<T> values, PopularCursor cursor, int limit
+    ) {
+        boolean hasPrevious = checkFirstPageByPopularity(cursor, values);
+        boolean hasNext = values.size() > limit;
+        List<T> trimmedValues = hasNext ? values.subList(0, limit) : values;
+
+        return new PopularCursorResult<>(trimmedValues, hasPrevious, hasNext);
+    }
+
+    private static <T extends PopularProvider> boolean checkFirstPageByPopularity(
+        PopularCursor cursor, List<T> values
+    ) {
+        if (cursor == null || values == null || values.isEmpty()) {
+            return false;
+        }
+        T first = values.getFirst();
+        return first.getLikeCount() > cursor.likeCount()
+            || (first.getLikeCount() == cursor.likeCount() && first.getCreatedAt().isAfter(cursor.createdAt()));
+    }
+}

--- a/src/main/java/com/saerok/showing/api/global/pagination/parser/CursorParser.java
+++ b/src/main/java/com/saerok/showing/api/global/pagination/parser/CursorParser.java
@@ -1,0 +1,43 @@
+package com.saerok.showing.api.global.pagination.parser;
+
+import com.saerok.showing.api.domain.post.entity.PostSortType;
+import com.saerok.showing.api.global.exception.ErrorCode;
+import com.saerok.showing.api.global.exception.ShowingException;
+import com.saerok.showing.api.global.pagination.cursor.CreatedAtCursor;
+import com.saerok.showing.api.global.pagination.cursor.PopularCursor;
+import lombok.experimental.UtilityClass;
+
+import java.time.LocalDateTime;
+
+@UtilityClass
+public class CursorParser {
+
+    public Object parse(String rawCursor, PostSortType sortType) {
+        if (rawCursor == null || rawCursor.isBlank()) {
+            return null;
+        }
+
+        try {
+            return switch (sortType) {
+                case LATEST -> parseCreatedAt(rawCursor);
+                case POPULAR -> parsePopular(rawCursor);
+            };
+        } catch (Exception e) {
+            throw ShowingException.from(ErrorCode.INVALID_CURSOR_FORMAT);
+        }
+    }
+
+    private CreatedAtCursor parseCreatedAt(String rawCursor) {
+        return new CreatedAtCursor(LocalDateTime.parse(rawCursor));
+    }
+
+    private PopularCursor parsePopular(String rawCursor) {
+        String[] parts = rawCursor.split(",");
+        if (parts.length != 2) {
+            throw ShowingException.from(ErrorCode.INVALID_CURSOR_FORMAT);
+        }
+        int likeCount = Integer.parseInt(parts[0]);
+        LocalDateTime createdAt = LocalDateTime.parse(parts[1]);
+        return new PopularCursor(likeCount, createdAt);
+    }
+}

--- a/src/main/java/com/saerok/showing/api/global/pagination/provider/PopularProvider.java
+++ b/src/main/java/com/saerok/showing/api/global/pagination/provider/PopularProvider.java
@@ -1,0 +1,10 @@
+package com.saerok.showing.api.global.pagination.provider;
+
+import java.time.LocalDateTime;
+
+public interface PopularProvider {
+
+    int getLikeCount();
+
+    LocalDateTime getCreatedAt();
+}


### PR DESCRIPTION
## ⭐️ Overview

> #42

게시글 조회 API에 커서 기반 페이지네이션을 도입했습니다.
정렬 방식(최신순, 인기순)에 따라 전략을 다르게 적용하도록 리팩토링했습니다.

## 🔧 Tasks

- 커서 기반 페이지네이션 전략 패턴 도입
- 최신순 / 인기순 정렬 방식 분리하여 전략 패턴 구현
- 커서 파싱 및 결과 처리 로직 추가

## 📝 Additional Notes

- 커서 기반 페이지네이션은 무한 스크롤 UX에 적용할 구조입니다.
- 전략 패턴을 통해 정렬 방식별로 페이지네이션 전략을 유연하게 확장 가능하도록 구성했습니다.
- 최신순 정렬은 `createdAt`(작성일시)을 기준으로 정렬합니다.
  - 커서 형식 예시: 2025-08-06T15:10:00
- 인기순 정렬은 `likeCount`를 우선 기준으로, `createdAt`을 보조 정렬로 사용하는 복합 커서 구조입니다.
  - 커서 형식 예시: 23|2025-08-06T15:10:00

## 🧭 페이지네이션 적용 흐름
- 최초 요청: `cursor` 없이 요청 → 최신 게시글부터 시작
- 다음 페이지 요청: 응답의 마지막 항목의 `cursor`(createdAt or likeCount|createdAt)를 포함해 요청
- `hasNext`: 다음 페이지 존재 여부 판단 플래그 (`limit` + 1 로 조회하여 판별)

## 📸 Screenshot

### 1. 최신순 페이지네이션 - 첫 페이지 (커서 없음)

<img width="750" alt="최신순 첫 페이지 1" src="https://github.com/user-attachments/assets/c9422cfe-3c0b-4d2b-8942-559417334dee" />
<img width="750" alt="최신순 첫 페이지 2" src="https://github.com/user-attachments/assets/c867143d-25a9-4026-8f6b-8d4015233601" />

### 2. 최신순 페이지네이션 - 다음 페이지 (커서 포함)

<img width="750" alt="최신순 다음 페이지" src="https://github.com/user-attachments/assets/90fed662-092c-426c-8c9d-64be9e928e4b" />

### 3. 인기순 페이지네이션 - 첫 페이지 (커서 없음)

<img width="750" alt="인기순 첫 페이지 1" src="https://github.com/user-attachments/assets/61dfeb1d-0684-4b01-9f2e-c8666290e0e7" />
<img width="750" alt="인기순 첫 페이지 2" src="https://github.com/user-attachments/assets/43da0ad9-9874-4ac1-8919-d2050e5a00ec" />

### 4. 인기순 페이지네이션 - 다음 페이지 (커서 포함)

<img width="750" alt="인기순 다음 페이지" src="https://github.com/user-attachments/assets/9e849d67-b2b1-4702-acc7-5729a82a8bac" />
