### PR TITLE
refactor: placeName 기반으로 내 여행 루트 장소 리팩토링

### DIFF
--- a/src/main/java/com/saerok/showing/api/domain/place/dto/response/PlaceSummaryResponse.java
+++ b/src/main/java/com/saerok/showing/api/domain/place/dto/response/PlaceSummaryResponse.java
@@ -1,6 +1,5 @@
 package com.saerok.showing.api.domain.place.dto.response;
 
-import com.saerok.showing.api.domain.place.entity.Place;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -8,14 +7,11 @@ import lombok.Getter;
 @Builder
 public class PlaceSummaryResponse {
 
-    private Long id;
-
     private String title;
 
-    public static PlaceSummaryResponse create(Place place) {
+    public static PlaceSummaryResponse create(String placeName) {
         return PlaceSummaryResponse.builder()
-            .id(place.getId())
-            .title(place.getTitle())
+            .title(placeName)
             .build();
     }
 }

--- a/src/main/java/com/saerok/showing/api/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/com/saerok/showing/api/domain/place/repository/PlaceRepository.java
@@ -10,6 +10,8 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface PlaceRepository extends JpaRepository<Place, Long> {
 
+    Place findByTitleContainingIgnoreCase(String title);
+
     @Query("""
             SELECT p FROM Place p
             WHERE p.locationY BETWEEN :minLat AND :maxLat

--- a/src/main/java/com/saerok/showing/api/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/com/saerok/showing/api/domain/place/repository/PlaceRepository.java
@@ -10,8 +10,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface PlaceRepository extends JpaRepository<Place, Long> {
 
-    Place findByTitleContainingIgnoreCase(String title);
-
     @Query("""
             SELECT p FROM Place p
             WHERE p.locationY BETWEEN :minLat AND :maxLat

--- a/src/main/java/com/saerok/showing/api/domain/poll/service/PollService.java
+++ b/src/main/java/com/saerok/showing/api/domain/poll/service/PollService.java
@@ -42,7 +42,7 @@ public class PollService {
         List<RouteSummaryResponse> routeSummaries = poll.getRouteOptions().stream()
             .map(route -> {
                 List<PlaceSummaryResponse> placeSummaries = route.getRoutePlaces().stream()
-                    .map(routePlace -> PlaceSummaryResponse.create(routePlace.getPlace()))
+                    .map(routePlace -> PlaceSummaryResponse.create(routePlace.getPlaceName()))
                     .toList();
                 return RouteSummaryResponse.toDto(route, placeSummaries);
             })

--- a/src/main/java/com/saerok/showing/api/domain/route/service/RouteService.java
+++ b/src/main/java/com/saerok/showing/api/domain/route/service/RouteService.java
@@ -41,7 +41,7 @@ public class RouteService {
                     .sorted(Comparator.comparingInt(RoutePlace::getDayNumber)
                         .thenComparingInt(RoutePlace::getOrderInDay))
                     .limit(3)
-                    .map(routePlace -> PlaceSummaryResponse.create(routePlace.getPlace()))
+                    .map(routePlace -> PlaceSummaryResponse.create(routePlace.getPlaceName()))
                     .toList();
 
                 return RouteSummaryResponse.toDto(route, topPlaces);

--- a/src/main/java/com/saerok/showing/api/domain/routePlace/controller/RoutePlaceController.java
+++ b/src/main/java/com/saerok/showing/api/domain/routePlace/controller/RoutePlaceController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -68,13 +69,12 @@ public class RoutePlaceController {
             """
     )
     @PreAuthorize("hasRole('MEMBER')")
-    @PatchMapping("/{routeId}/places/{routePlaceId}")
+    @PatchMapping("/{routeId}/places")
     public ApiResponse<Long> updateRoutePlace(
         @PathVariable Long routeId,
-        @PathVariable Long routePlaceId,
         @Valid @RequestBody RoutePlaceUpdateRequest request
     ) {
-        Long updatedId = routePlaceService.updateRoutePlace(routeId, routePlaceId, request);
+        Long updatedId = routePlaceService.updateRoutePlace(routeId, request);
         return ApiResponse.success(updatedId);
     }
 
@@ -82,16 +82,19 @@ public class RoutePlaceController {
         summary = "여행코스 내 장소 삭제",
         description = """
             [모든 Role 가능] 특정 여행코스에서 지정한 장소(routePlace)를 삭제합니다.<br>
+            장소는 여행 일자(dayNumber)와 해당 일자의 순서(orderInDay)를 입력받아 삭제합니다.<br>
             장소를 삭제하면 해당 일차의 나머지 순서에는 영향을 주지 않습니다.
             """
     )
     @PreAuthorize("hasRole('MEMBER')")
-    @DeleteMapping("/{routeId}/places/{routePlaceId}")
+    @DeleteMapping("/{routeId}/places")
     public ApiResponse<Long> deleteRoutePlace(
         @PathVariable Long routeId,
-        @PathVariable Long routePlaceId
+        @RequestParam int dayNumber,
+        @RequestParam int orderInDay
+
     ) {
-        Long deletedId = routePlaceService.deleteRoutePlace(routeId, routePlaceId);
+        Long deletedId = routePlaceService.deleteRoutePlace(routeId, dayNumber, orderInDay);
         return ApiResponse.success(deletedId);
     }
 }

--- a/src/main/java/com/saerok/showing/api/domain/routePlace/dto/request/RoutePlaceCreateRequest.java
+++ b/src/main/java/com/saerok/showing/api/domain/routePlace/dto/request/RoutePlaceCreateRequest.java
@@ -12,8 +12,8 @@ import lombok.Setter;
 public class RoutePlaceCreateRequest {
 
     @NotNull
-    @Schema(description = "추가할 장소의 ID", example = "1")
-    private Long placeId;
+    @Schema(description = "추가할 장소의 이름", example = "엘리시안 강촌 리조트")
+    private String placeName;
 
     @Min(1)
     @Max(30)

--- a/src/main/java/com/saerok/showing/api/domain/routePlace/dto/request/RoutePlaceUpdateRequest.java
+++ b/src/main/java/com/saerok/showing/api/domain/routePlace/dto/request/RoutePlaceUpdateRequest.java
@@ -11,15 +11,22 @@ import lombok.Setter;
 @Setter
 public class RoutePlaceUpdateRequest {
 
-    @Min(1)
-    @Max(30)
-    @NotNull
-    @Schema(description = "여행 경로에서 해당 장소의 방문 일자(Day N)를 수정합니다, N은 1~30의 값입니다.", example = "1")
-    private int dayNumber;
+    @Min(1) @Max(30) @NotNull
+    @Schema(description = "기존 일차(이동 전)", example = "1")
+    private Integer oldDayNumber;
 
-    @Min(1)
-    @Max(30)
-    @NotNull
-    @Schema(description = "해당 일자 내에서 장소 방문 순서를 수정합니다. 1~30의 값을 가집니다.", example = "1")
-    private int orderInDay;
+    @Min(1) @Max(30) @NotNull
+    @Schema(description = "기존 순서(이동 전)", example = "2")
+    private Integer oldOrderInDay;
+
+    @Min(1) @Max(30) @NotNull
+    @Schema(description = "새 일차(이동 후)", example = "1")
+    private Integer dayNumber;
+
+    @Min(1) @Max(30) @NotNull
+    @Schema(description = "새 순서(이동 후)", example = "1")
+    private Integer orderInDay;
+
+    @Schema(description = "장소 이름", example = "엘리시안 강촌 리조트")
+    private String placeName;
 }

--- a/src/main/java/com/saerok/showing/api/domain/routePlace/dto/response/RoutePlaceBoxResponse.java
+++ b/src/main/java/com/saerok/showing/api/domain/routePlace/dto/response/RoutePlaceBoxResponse.java
@@ -8,8 +8,6 @@ import lombok.Getter;
 @Builder
 public class RoutePlaceBoxResponse {
 
-    private Long id;
-
     private String title;
 
     private int dayNumber;
@@ -20,7 +18,6 @@ public class RoutePlaceBoxResponse {
 
     public static RoutePlaceBoxResponse toDto(RoutePlace routePlace) {
         return RoutePlaceBoxResponse.builder()
-            .id(routePlace.getId())
             .title(routePlace.getPlaceName())
             .dayNumber(routePlace.getDayNumber())
             .orderInDay(routePlace.getOrderInDay())

--- a/src/main/java/com/saerok/showing/api/domain/routePlace/dto/response/RoutePlaceBoxResponse.java
+++ b/src/main/java/com/saerok/showing/api/domain/routePlace/dto/response/RoutePlaceBoxResponse.java
@@ -16,15 +16,15 @@ public class RoutePlaceBoxResponse {
 
     private int orderInDay;
 
-    private String imageUrl;
+//    private String imageUrl;
 
     public static RoutePlaceBoxResponse toDto(RoutePlace routePlace) {
         return RoutePlaceBoxResponse.builder()
             .id(routePlace.getId())
-            .title(routePlace.getPlace().getTitle())
+            .title(routePlace.getPlaceName())
             .dayNumber(routePlace.getDayNumber())
             .orderInDay(routePlace.getOrderInDay())
-            .imageUrl(routePlace.getPlace().getPlaceImage())
+//            .imageUrl(routePlace.getPlace().getPlaceImage())
             .build();
     }
 }

--- a/src/main/java/com/saerok/showing/api/domain/routePlace/entity/RoutePlace.java
+++ b/src/main/java/com/saerok/showing/api/domain/routePlace/entity/RoutePlace.java
@@ -1,6 +1,5 @@
 package com.saerok.showing.api.domain.routePlace.entity;
 
-import com.saerok.showing.api.domain.place.entity.Place;
 import com.saerok.showing.api.domain.route.entity.Route;
 import com.saerok.showing.api.domain.routePlace.dto.request.RoutePlaceCreateRequest;
 import com.saerok.showing.api.domain.routePlace.dto.request.RoutePlaceUpdateRequest;
@@ -41,9 +40,8 @@ public class RoutePlace extends BaseEntity {
     @JoinColumn(name = "route_id", nullable = false)
     private Route route;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "place_id", nullable = false)
-    private Place place;
+    @Column(name = "place_name", nullable = false)
+    private String placeName;
 
     @Column(name = "day_number", nullable = false)
     private int dayNumber;
@@ -51,10 +49,10 @@ public class RoutePlace extends BaseEntity {
     @Column(name = "order_in_day", nullable = false)
     private int orderInDay;
 
-    public static RoutePlace toEntity(RoutePlaceCreateRequest request, Route route, Place place) {
+    public static RoutePlace toEntity(RoutePlaceCreateRequest request, Route route, String PlaceName) {
         return RoutePlace.builder()
             .route(route)
-            .place(place)
+            .placeName(PlaceName)
             .dayNumber(request.getDayNumber())
             .orderInDay(request.getOrderInDay())
             .build();
@@ -63,6 +61,23 @@ public class RoutePlace extends BaseEntity {
     public void update(RoutePlaceUpdateRequest request) {
         this.dayNumber = request.getDayNumber();
         this.orderInDay = request.getOrderInDay();
+        this.placeName = request.getPlaceName();
+    }
+
+    // 같은 day 내 임시 파킹 (유니크 충돌 방지용)
+    public void parkOrder() {
+        this.orderInDay = -1;
+    }
+
+    // 같은 day 내에서 새로운 order로 이동
+    public void placeAt(int newOrder) {
+        this.orderInDay = newOrder;
+    }
+
+    // 다른 day로 이동하며 order도 설정
+    public void moveTo(int newDay, int newOrder) {
+        this.dayNumber = newDay;
+        this.orderInDay = newOrder;
     }
 
     public void validateBelongsTo(Route route) {

--- a/src/main/java/com/saerok/showing/api/domain/routePlace/repository/RoutePlaceRepository.java
+++ b/src/main/java/com/saerok/showing/api/domain/routePlace/repository/RoutePlaceRepository.java
@@ -3,15 +3,59 @@ package com.saerok.showing.api.domain.routePlace.repository;
 import com.saerok.showing.api.domain.route.entity.Route;
 import com.saerok.showing.api.domain.routePlace.entity.RoutePlace;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RoutePlaceRepository extends JpaRepository<RoutePlace, Long> {
 
+    Optional<RoutePlace> findByRouteIdAndDayNumberAndOrderInDay(Long routeId, int dayNumber, int orderInDay);
+
     List<RoutePlace> findByRouteOrderByDayNumberAscOrderInDayAsc(Route route);
+
+    @Modifying(clearAutomatically = true)
+    @Query("""
+            update RoutePlace rp
+               set rp.orderInDay = rp.orderInDay - 1
+             where rp.route.id = :routeId
+               and rp.dayNumber = :dayNumber
+               and rp.orderInDay > :oldOrder
+               and rp.orderInDay <= :newOrder
+        """)
+    void shiftRangeBackwardWithinDay(@Param("routeId") Long routeId,
+        @Param("dayNumber") int dayNumber,
+        @Param("oldOrder") int oldOrder,
+        @Param("newOrder") int newOrder);
+
+    @Modifying(clearAutomatically = true)
+    @Query("""
+            update RoutePlace rp
+               set rp.orderInDay = rp.orderInDay + 1
+             where rp.route.id = :routeId
+               and rp.dayNumber = :dayNumber
+               and rp.orderInDay >= :newOrder
+               and rp.orderInDay < :oldOrder
+        """)
+    void shiftRangeForwardWithinDay(@Param("routeId") Long routeId,
+        @Param("dayNumber") int dayNumber,
+        @Param("newOrder") int newOrder,
+        @Param("oldOrder") int oldOrder);
+
+    @Modifying
+    @Query("""
+        update RoutePlace rp
+           set rp.orderInDay = rp.orderInDay - 1
+         where rp.route.id = :routeId
+           and rp.dayNumber = :dayNumber
+           and rp.orderInDay > :deletedOrder
+        """)
+    void shiftOrdersBackwardAfterDelete(@Param("routeId") Long routeId,
+        @Param("dayNumber") int dayNumber,
+        @Param("deletedOrder") int deletedOrder);
 
     @Modifying
     @Query("""
@@ -24,4 +68,6 @@ public interface RoutePlaceRepository extends JpaRepository<RoutePlace, Long> {
     void shiftOrdersForward(Long routeId, int dayNumber, int startOrder);
 
     boolean existsByRouteIdAndDayNumberAndOrderInDay(Long routeId, int dayNumber, int orderInDay);
+
+    Optional<RoutePlace> findByPlaceName(String name);
 }

--- a/src/main/java/com/saerok/showing/api/domain/routePlace/service/RoutePlaceService.java
+++ b/src/main/java/com/saerok/showing/api/domain/routePlace/service/RoutePlaceService.java
@@ -1,8 +1,6 @@
 package com.saerok.showing.api.domain.routePlace.service;
 
 import com.saerok.showing.api.domain.member.entity.Member;
-import com.saerok.showing.api.domain.place.entity.Place;
-import com.saerok.showing.api.domain.place.service.PlaceService;
 import com.saerok.showing.api.domain.route.entity.Route;
 import com.saerok.showing.api.domain.route.service.RouteService;
 import com.saerok.showing.api.domain.routePlace.dto.request.RoutePlaceCreateRequest;
@@ -24,16 +22,14 @@ public class RoutePlaceService {
 
     private final RoutePlaceRepository routePlaceRepository;
     private final RouteService routeService;
-    private final PlaceService placeService;
     private final LoginMemberProvider loginMemberProvider;
 
     @Transactional
     public Long addRoutePlace(Long routeId, RoutePlaceCreateRequest request) {
         Member currentMember = loginMemberProvider.getCurrentLoginMember();
         Route route = findRouteWithOwnerValidation(routeId, currentMember);
-        Place place = placeService.findById(request.getPlaceId());
         shiftOrderIfDuplicate(routeId, request.getDayNumber(), request.getOrderInDay());
-        RoutePlace routePlace = RoutePlace.toEntity(request, route, place);
+        RoutePlace routePlace = RoutePlace.toEntity(request, route, request.getPlaceName());
         routePlaceRepository.save(routePlace);
         return routePlace.getId();
     }
@@ -47,11 +43,12 @@ public class RoutePlaceService {
     }
 
     @Transactional
-    public Long updateRoutePlace(Long routeId, Long routePlaceId, RoutePlaceUpdateRequest request) {
+    public Long updateRoutePlace(Long routeId, RoutePlaceUpdateRequest request) {
         Member currentMember = loginMemberProvider.getCurrentLoginMember();
         Route route = findRouteWithOwnerValidation(routeId, currentMember);
-        RoutePlace routePlace = findById(routePlaceId);
+        RoutePlace routePlace = findByName(request.getPlaceName());
         if (isUpdateRequired(routePlace, request)) {
+            reorderForUpdate(routeId, routePlace, request);
             shiftOrderIfDuplicate(routeId, request.getDayNumber(), request.getOrderInDay());
         }
         routePlace.validateBelongsTo(route);
@@ -60,18 +57,66 @@ public class RoutePlaceService {
     }
 
     @Transactional
-    public Long deleteRoutePlace(Long routeId, Long routePlaceId) {
+    public Long deleteRoutePlace(Long routeId, int dayNumber, int orderInDay) {
         Member currentMember = loginMemberProvider.getCurrentLoginMember();
         Route route = findRouteWithOwnerValidation(routeId, currentMember);
-        RoutePlace routePlace = findById(routePlaceId);
+        RoutePlace routePlace = findRoutePlace(routeId, dayNumber, orderInDay);
+        Long routePlaceId = routePlace.getId();
         routePlace.validateBelongsTo(route);
         routePlaceRepository.delete(routePlace);
+        routePlaceRepository.shiftOrdersBackwardAfterDelete(routeId, dayNumber, orderInDay); // 삭제된 장소 뒤의 장소들 재정렬
         return routePlaceId;
     }
 
     @Transactional(readOnly = true)
     public List<RoutePlace> findByRouteOrderByDayNumberAscOrderInDayAsc(Route route) {
         return routePlaceRepository.findByRouteOrderByDayNumberAscOrderInDayAsc(route);
+    }
+
+    @Transactional(readOnly = true)
+    public RoutePlace findByName(String name) {
+        return routePlaceRepository.findByPlaceName(name)
+            .orElseThrow(() -> ShowingException.from(ErrorCode.ROUTE_PLACE_NOT_FOUND));
+    }
+
+    private RoutePlace findRoutePlace(Long routeId, int dayNumber, int orderInDay) {
+        return routePlaceRepository.findByRouteIdAndDayNumberAndOrderInDay(routeId, dayNumber, orderInDay)
+            .orElseThrow(() -> ShowingException.from(ErrorCode.ROUTE_PLACE_NOT_FOUND));
+    }
+
+    private void reorderForUpdate(Long routeId, RoutePlace routePlace, RoutePlaceUpdateRequest req) {
+        int oldDay = routePlace.getDayNumber();
+        int oldOrder = routePlace.getOrderInDay();
+        int newDay = req.getDayNumber();
+        int newOrder = req.getOrderInDay();
+
+        // 1. 이동 여부 확인
+        if (oldDay == newDay && oldOrder == newOrder) return;
+        // 2. 임시 파킹(유니크 제약 조건 충돌 방지)
+        routePlace.parkOrder();
+        // 3. 순서 재배치
+        if (oldDay == newDay) {
+            // 3-1. 같은 일차 내 이동
+            if (newOrder > oldOrder) {
+                shiftRangeBackwardWithinDay(routeId, oldDay, oldOrder, newOrder);
+            } else {
+                shiftRangeForwardWithinDay(routeId, oldDay, newOrder, oldOrder);
+            }
+            routePlace.placeAt(newOrder);
+        } else {
+            // 3-2. 다른 일차로 이동
+            routePlaceRepository.shiftOrdersBackwardAfterDelete(routeId, oldDay, oldOrder);
+            routePlaceRepository.shiftOrdersForward(routeId, newDay, newOrder);
+            routePlace.moveTo(newDay, newOrder);
+        }
+    }
+
+    private void shiftRangeBackwardWithinDay(Long routeId, int dayNumber, int oldOrder, int newOrder) {
+        routePlaceRepository.shiftRangeBackwardWithinDay(routeId, dayNumber, oldOrder, newOrder);
+    }
+
+    private void shiftRangeForwardWithinDay(Long routeId, int dayNumber, int newOrder, int oldOrder) {
+        routePlaceRepository.shiftRangeForwardWithinDay(routeId, dayNumber, newOrder, oldOrder);
     }
 
     private void shiftOrderIfDuplicate(Long routeId, int dayNumber, int orderInDay) {


### PR DESCRIPTION
## ⭐️ Overview

> #47 

`placeName` 기반으로 내 여행 루트 장소(RoutePlace) API 전반을 리팩토링했습니다.

## 🔧 Tasks

- RoutePlaceService, Repository, Controller 전반을 `placeName` 중심으로 리팩터링
- 요청/응답 DTO의 주요 필드를 placeName 기반으로 변경
- 여행 루트 내 장소 수정 시 순서 재정렬 로직 개선

## 📝 Additional Notes

- API 경로 변경
`/{routeId}/places/{routePlaceId}` -> `/{routeId}/places`

## 📸 Screenshot

### 여행루트 내 장소 수정 테스트(현재는 `id` 필드는 삭제)
2번째 장소(감자 축제)를 2일차 첫 번째 장소로 이동 → 나머지 방문 순서가 자동 재정렬 되는지 확인

<img width="700" alt="image" src="https://github.com/user-attachments/assets/f038512a-67b5-4945-ac8d-9bcd7018a2e1" />  
<img width="700" alt="image" src="https://github.com/user-attachments/assets/85489278-aba4-4ba3-9ee2-880ae77ab936" />  
<img width="700" alt="image" src="https://github.com/user-attachments/assets/572b6ccd-2eea-4d19-876e-188d487258b9" />  
<img width="700" alt="image" src="https://github.com/user-attachments/assets/5ed17170-22e1-46aa-beea-2808ae8e4318" />  
<img width="700" alt="image" src="https://github.com/user-attachments/assets/ddb1a726-20e7-4e91-a511-0aa842c29dfc" />  
