### PR TITLE
refactor: 여행코스 이름 수정 API 엔드포인트 추가

### DIFF
--- a/src/main/java/com/saerok/showing/api/domain/route/controller/RouteController.java
+++ b/src/main/java/com/saerok/showing/api/domain/route/controller/RouteController.java
@@ -1,6 +1,7 @@
 package com.saerok.showing.api.domain.route.controller;
 
 import com.saerok.showing.api.domain.route.dto.request.RouteCreateRequest;
+import com.saerok.showing.api.domain.route.dto.request.RouteUpdateRequest;
 import com.saerok.showing.api.domain.route.service.RouteService;
 import com.saerok.showing.api.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,6 +10,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -18,7 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/route")
 @RequiredArgsConstructor
-@Tag(name = "Route", description = "여행코스 생성/삭제")
+@Tag(name = "Route", description = "여행코스 관리")
 public class RouteController {
 
     private final RouteService routeService;
@@ -37,6 +39,23 @@ public class RouteController {
         @Valid @RequestBody RouteCreateRequest request
     ) {
         Long id = routeService.save(request);
+        return ApiResponse.success(id);
+    }
+
+    @Operation(
+        summary = "여행코스 수정",
+        description = """
+            [MEMBER] 여행코스의 제목을 수정합니다.<br>
+            본인이 생성한 여행코스만 수정할 수 있으며, 1~50자 내의 이름만 가능합니다.
+            """
+    )
+    @PreAuthorize("hasRole('MEMBER')")
+    @PatchMapping("/{routeId}")
+    public ApiResponse<Long> updateRoute(
+        @PathVariable(name = "routeId") Long routeId,
+        @Valid @RequestBody RouteUpdateRequest request
+    ) {
+        Long id = routeService.update(routeId, request);
         return ApiResponse.success(id);
     }
 

--- a/src/main/java/com/saerok/showing/api/domain/route/controller/RouteController.java
+++ b/src/main/java/com/saerok/showing/api/domain/route/controller/RouteController.java
@@ -45,8 +45,8 @@ public class RouteController {
     @Operation(
         summary = "여행코스 수정",
         description = """
-            [MEMBER] 여행코스의 제목을 수정합니다.<br>
-            본인이 생성한 여행코스만 수정할 수 있으며, 1~50자 내의 이름만 가능합니다.
+            [모든 Role 가능] 여행코스의 제목을 수정합니다.<br>
+            본인이 생성한 여행코스만 수정할 수 있으며, 1~50자 길이의 여행코스 제목으로만 수정이 가능합니다.
             """
     )
     @PreAuthorize("hasRole('MEMBER')")

--- a/src/main/java/com/saerok/showing/api/domain/route/dto/request/RouteCreateRequest.java
+++ b/src/main/java/com/saerok/showing/api/domain/route/dto/request/RouteCreateRequest.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import lombok.Getter;
 import lombok.Setter;
@@ -12,7 +13,8 @@ import lombok.Setter;
 @Setter
 public class RouteCreateRequest {
 
-    @Min(1) @Max(50) @NotNull
+    @NotNull
+    @Size(min = 1, max = 50)
     @Schema(description = "내 여행코스 이름, 여행코스는 1자 이상 50자 이하여야 합니다.", example = "5학년 3반 나들이 여행코스")
     private String title;
 

--- a/src/main/java/com/saerok/showing/api/domain/route/dto/request/RouteCreateRequest.java
+++ b/src/main/java/com/saerok/showing/api/domain/route/dto/request/RouteCreateRequest.java
@@ -12,21 +12,19 @@ import lombok.Setter;
 @Setter
 public class RouteCreateRequest {
 
-    @NotNull
-    @Schema(description = "내 여행코스 이름", example = "5학년 3반 나들이 여행코스")
+    @Min(1) @Max(50) @NotNull
+    @Schema(description = "내 여행코스 이름, 여행코스는 1자 이상 50자 이하여야 합니다.", example = "5학년 3반 나들이 여행코스")
     private String title;
 
     @NotNull
-    @Schema(description = "여행 시작일(yyyy-MM-dd)", example = "2025-07-08")
+    @Schema(description = "여행 시작일(yyyy-MM-dd)", example = "2025-09-18")
     private LocalDate startDate;
 
     @NotNull
-    @Schema(description = "여행 종료일(yyyy-MM-dd)", example = "2025-07-08")
+    @Schema(description = "여행 종료일(yyyy-MM-dd)", example = "2025-09-18")
     private LocalDate endDate;
 
-    @Min(1)
-    @Max(100)
-    @NotNull
+    @Min(1) @Max(100) @NotNull
     @Schema(description = "인원수, 1~100의 값을 가질 수 있습니다.", example = "15")
     private int peopleCount;
 }

--- a/src/main/java/com/saerok/showing/api/domain/route/dto/request/RouteUpdateRequest.java
+++ b/src/main/java/com/saerok/showing/api/domain/route/dto/request/RouteUpdateRequest.java
@@ -2,6 +2,7 @@ package com.saerok.showing.api.domain.route.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -10,6 +11,7 @@ import lombok.Setter;
 public class RouteUpdateRequest {
 
     @NotNull
-    @Schema(description = "내 여행코스 이름", example = "5학년 3반 끝내주는 나들이 여행코스")
+    @Size(min = 1, max = 50)
+    @Schema(description = "내 여행코스 이름, 여행코스는 1자 이상 50자 이하여야 합니다.", example = "5학년 3반 끝내주는 피크닉 코스")
     private String title;
 }

--- a/src/main/java/com/saerok/showing/api/domain/route/dto/request/RouteUpdateRequest.java
+++ b/src/main/java/com/saerok/showing/api/domain/route/dto/request/RouteUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.saerok.showing.api.domain.route.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class RouteUpdateRequest {
+
+    @NotNull
+    @Schema(description = "내 여행코스 이름", example = "5학년 3반 끝내주는 나들이 여행코스")
+    private String title;
+}

--- a/src/main/java/com/saerok/showing/api/domain/route/entity/Route.java
+++ b/src/main/java/com/saerok/showing/api/domain/route/entity/Route.java
@@ -85,6 +85,13 @@ public class Route extends BaseEntity {
         }
     }
 
+    public void updateTitle(String title) {
+        if (title == null || title.isBlank()) {
+            throw ShowingException.from(ErrorCode.INVALID_ROUTE_TITLE);
+        }
+        this.title = title;
+    }
+
     public void increaseLikeCount() {
         this.likeCount++;
     }

--- a/src/main/java/com/saerok/showing/api/domain/route/service/RouteService.java
+++ b/src/main/java/com/saerok/showing/api/domain/route/service/RouteService.java
@@ -3,6 +3,7 @@ package com.saerok.showing.api.domain.route.service;
 import com.saerok.showing.api.domain.member.entity.Member;
 import com.saerok.showing.api.domain.place.dto.response.PlaceSummaryResponse;
 import com.saerok.showing.api.domain.route.dto.request.RouteCreateRequest;
+import com.saerok.showing.api.domain.route.dto.request.RouteUpdateRequest;
 import com.saerok.showing.api.domain.route.dto.response.RouteSummaryResponse;
 import com.saerok.showing.api.domain.route.entity.Route;
 import com.saerok.showing.api.domain.route.repository.RouteRepository;
@@ -28,6 +29,15 @@ public class RouteService {
         Member member = loginMemberProvider.getCurrentLoginMember();
         Route route = Route.toEntity(member, request);
         return routeRepository.save(route).getId();
+    }
+
+    @Transactional
+    public Long update(Long routeId, RouteUpdateRequest request) {
+        Member currentMember = loginMemberProvider.getCurrentLoginMember();
+        Route route = findById(routeId);
+        route.validateOwner(currentMember);
+        route.updateTitle(request.getTitle());
+        return route.getId();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/saerok/showing/api/global/exception/ErrorCode.java
+++ b/src/main/java/com/saerok/showing/api/global/exception/ErrorCode.java
@@ -17,6 +17,8 @@ public enum ErrorCode {
     INVALID_LIKE_TARGET_TYPE(HttpStatus.BAD_REQUEST, "올바르지 않은 좋아요 대상 타입입니다."),
     UNSUPPORTED_SORT_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 정렬 방식입니다."),
     INVALID_CURSOR_FORMAT(HttpStatus.BAD_REQUEST, "커서 형식이 잘못되었습니다."),
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "유효하지 않은 입력 값입니다."),
+    INVALID_ROUTE_TITLE(HttpStatus.BAD_REQUEST, "여행코스 제목이 비어 있거나 올바르지 않습니다."),
 
     // 401: UNAUTHORIZED (인증 실패)
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),


### PR DESCRIPTION
## ⭐️ Overview

> #48

여행코스 이름 수정 API 엔드포인트를 추가했습니다.

## 🔧 Tasks

- 여행코스 수정 API (PATCH `/api/v1/route/{routeId}`) 추가

## 📝 Additional Notes

- 여행코스 제목에 대해 수정이 가능하며, 길이는 1자 이상 50자 이내로 제한하였습니다.

## 📸 Screenshot

### 여행코스 제목 수정
<img width="600" alt="여행코스 이름 수정 API 사진" src="https://github.com/user-attachments/assets/1d4aca36-5554-4656-825b-1371b421ce65" />

