### PR TITLE
hotfix: Spring 컨테이너와 Redis 네트워크 통일

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,37 +79,32 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      # Scan image
-#      - name: Scan image
-#        uses: anchore/scan-action@v6
-#        with:  
-#          image: ${{ secrets.DOCKERHUB_USERNAME }}/github-actions-showing:latest
-#          output-format: table
-
       # Docker Hub 이미지 푸시
       - name: docker Hub push
         run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/github-actions-showing
 
   run-docker-image-on-ec2:
-    # build-docker-image 과정이 완료되어야 실행
     needs: build-docker-image
     runs-on: self-hosted
 
     steps:
-      # 최신 이미지를 pull
+      - name: ensure network exists
+        run: sudo docker network inspect app-net >/dev/null 2>&1 || sudo docker network create app-net
+
       - name: docker pull
-        run: sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/github-actions-showing
+        run: sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/github-actions-showing:latest
 
-      # 기존의 컨테이너 중지
-      - name: docker stop container
-        run: sudo docker stop spring 2>/dev/null || true
-
-      # 최신 이미지를 컨테이너화하여 실행
-      - name: docker run new container
+      - name: stop & remove previous
         run: |
-          sudo docker run --name spring \
-            --network app_showing-network \
-            --rm -d \
+          sudo docker stop spring 2>/dev/null || true
+          sudo docker rm spring 2>/dev/null || true
+
+      - name: run spring on same network as redis
+        run: |
+          sudo docker run -d --name spring \
+            --network app-net \
+            --restart unless-stopped \
             -p ${{ secrets.SERVER_PORT }}:${{ secrets.SERVER_PORT }} \
             -e SERVER_PORT=${{ secrets.SERVER_PORT }} \
-            ${{ secrets.DOCKERHUB_USERNAME }}/github-actions-showing
+            -e SPRING_PROFILES_ACTIVE=${{ secrets.SPRING_PROFILES_ACTIVE }} \
+            ${{ secrets.DOCKERHUB_USERNAME }}/github-actions-showing:latest


### PR DESCRIPTION
## ⭐️ Overview

Spring 컨테이너와 Redis 컨테이너 간의 네트워크 연결 오류(UnknownHostException: redis)를 해결했습니다.
컨테이너 네트워크를 통일하고 환경변수를 재설정하여 Redis 연결이 정상적으로 동작하도록 수정했습니다.

## 🔧 Tasks

- pring/Redis 컨테이너를 동일한 Docker 네트워크(app-net)에 연결
- Redis 컨테이너 alias를 redis로 고정하여 DNS 이름 해석 오류 해결
- Spring 컨테이너 환경변수(REDIS_HOST)를 redis로 설정
