### PR TITLE
refactor:조건별 테마 조회 응답에 제목 필드 추가

### DIFF
--- a/src/main/java/com/saerok/showing/api/domain/member/controller/MemberController.java
+++ b/src/main/java/com/saerok/showing/api/domain/member/controller/MemberController.java
@@ -53,7 +53,7 @@ public class MemberController {
     }
 
     @Operation(
-        summary = "회원 삭제",
+        summary = "회원 탈퇴",
         description = "[모든 Role 가능] 회원을 탈퇴합니다."
     )
     @PreAuthorize("hasRole('MEMBER')")

--- a/src/main/java/com/saerok/showing/api/domain/theme/controller/ThemeController.java
+++ b/src/main/java/com/saerok/showing/api/domain/theme/controller/ThemeController.java
@@ -27,7 +27,11 @@ public class ThemeController {
 
     @Operation(
         summary = "조건별 테마 조회",
-        description = "[모든 Role 가능] 계절과 시간대 조건으로 테마 목록을 조회합니다."
+        description = """
+            [모든 Role 가능] 계절과 시간대 조건으로 테마 목록을 조회합니다.<br>
+            Season: SPRING(봄), SUMMER(여름), AUTUMN(가을), WINTER(겨울)<br>
+            DayTime: DAY(낮), NIGHT(밤)
+            """
     )
     @PreAuthorize("hasRole('MEMBER')")
     @GetMapping("")

--- a/src/main/java/com/saerok/showing/api/domain/theme/dto/response/ThemePinResponse.java
+++ b/src/main/java/com/saerok/showing/api/domain/theme/dto/response/ThemePinResponse.java
@@ -13,6 +13,8 @@ public class ThemePinResponse {
 
     private Long id;
 
+    private String title;
+
     private List<Season> seasons;
 
     private List<DayTime> dayTimes;
@@ -24,6 +26,7 @@ public class ThemePinResponse {
     public static ThemePinResponse toDto(Theme theme) {
         return ThemePinResponse.builder()
             .id(theme.getId())
+            .title(theme.getTitle())
             .seasons(theme.getSeasons())
             .dayTimes(theme.getDayTimes())
             .locationX(theme.getLocationX())


### PR DESCRIPTION
## ⭐️ Overview

> #50  
조건별 테마 조회 API 응답에 테마 제목(`title`) 필드를 포함하도록 수정했습니다.

## 🔧 Tasks

- `ThemePinResponse` DTO에 제목 필드 추가
- 관련 API 명세 보강

## 📝 Additional Notes

- 기존 API 응답 구조는 유지하면서 제목만 추가되었습니다.

## 📸 Screenshot

### 조건별 테마 조회
<img width="600" alt="조건별 테마 조회" src="https://github.com/user-attachments/assets/a4132714-ced7-4c36-b060-04f72c9d9b2e" />