### PR TITLE
refactor: 회원-팀 엔티티 구조 개선 및 게시글 가시성 필드 추가

### DIFF
--- a/src/main/java/com/saerok/showing/api/domain/member/entity/Member.java
+++ b/src/main/java/com/saerok/showing/api/domain/member/entity/Member.java
@@ -1,18 +1,14 @@
 package com.saerok.showing.api.domain.member.entity;
 
 import com.saerok.showing.api.domain.member.dto.request.MemberUpdateRequest;
-import com.saerok.showing.api.domain.team.entity.Team;
 import com.saerok.showing.api.global.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.util.Optional;
 import lombok.AccessLevel;
@@ -56,20 +52,8 @@ public class Member extends BaseEntity {
     @Column(name = "login_type", nullable = false)
     private LoginType loginType;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "team_id")
-    private Team team;
-
     public void update(MemberUpdateRequest memberUpdateRequest) {
         Optional.ofNullable(memberUpdateRequest.getName()).ifPresent(this::setName);
         Optional.ofNullable(memberUpdateRequest.getProfileImage()).ifPresent(this::setProfileImage);
-    }
-
-    public void joinTeam(Team team) {
-        this.team = team;
-    }
-
-    public void leaveTeam() {
-        this.team = null;
     }
 }

--- a/src/main/java/com/saerok/showing/api/domain/memberTeam/entity/MemberTeam.java
+++ b/src/main/java/com/saerok/showing/api/domain/memberTeam/entity/MemberTeam.java
@@ -1,0 +1,56 @@
+package com.saerok.showing.api.domain.memberTeam.entity;
+
+import com.saerok.showing.api.domain.member.entity.Member;
+import com.saerok.showing.api.domain.team.entity.Team;
+import com.saerok.showing.api.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(
+    name = "member_team",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_member_team", columnNames = {"member_id", "team_id"})
+    }
+)
+public class MemberTeam extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_team_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "team_id", nullable = false)
+    private Team team;
+
+    public static MemberTeam create(Member member, Team team) {
+        return MemberTeam.builder()
+            .member(member)
+            .team(team)
+            .build();
+    }
+}

--- a/src/main/java/com/saerok/showing/api/domain/memberTeam/repository/MemberTeamRepository.java
+++ b/src/main/java/com/saerok/showing/api/domain/memberTeam/repository/MemberTeamRepository.java
@@ -1,0 +1,31 @@
+package com.saerok.showing.api.domain.memberTeam.repository;
+
+import com.saerok.showing.api.domain.memberTeam.entity.MemberTeam;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberTeamRepository extends JpaRepository<MemberTeam, Long> {
+
+    boolean existsByMemberIdAndTeamId(Long memberId, Long teamId);
+
+    Optional<MemberTeam> findByMemberIdAndTeamId(Long memberId, Long teamId);
+
+    @Query("""
+            SELECT mt FROM MemberTeam mt
+            JOIN FETCH mt.member
+            WHERE mt.team.id = :teamId
+        """)
+    List<MemberTeam> findWithMemberByTeamId(@Param("teamId") Long teamId);
+
+    @Query("""
+            SELECT mt FROM MemberTeam mt
+            JOIN FETCH mt.team
+            WHERE mt.member.id = :memberId
+        """)
+    List<MemberTeam> findWithTeamByMemberId(@Param("memberId") Long memberId);
+}

--- a/src/main/java/com/saerok/showing/api/domain/memberTeam/service/MemberTeamService.java
+++ b/src/main/java/com/saerok/showing/api/domain/memberTeam/service/MemberTeamService.java
@@ -1,0 +1,64 @@
+package com.saerok.showing.api.domain.memberTeam.service;
+
+import com.saerok.showing.api.domain.member.entity.Member;
+import com.saerok.showing.api.domain.memberTeam.entity.MemberTeam;
+import com.saerok.showing.api.domain.memberTeam.repository.MemberTeamRepository;
+import com.saerok.showing.api.domain.team.entity.Team;
+import com.saerok.showing.api.global.exception.ErrorCode;
+import com.saerok.showing.api.global.exception.ShowingException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MemberTeamService {
+
+    private final MemberTeamRepository memberTeamRepository;
+
+    @Transactional
+    public void addMemberToTeam(Member member, Team team) {
+        validateNotAlreadyJoined(member, team);
+        MemberTeam memberTeam = MemberTeam.create(member, team);
+        memberTeamRepository.save(memberTeam);
+    }
+
+    @Transactional
+    public void removeMemberFromTeam(Member member, Team team) {
+        MemberTeam memberTeam = findById(member, team);
+        memberTeamRepository.delete(memberTeam);
+    }
+
+    // 특정 팀의 모든 멤버 조회
+    @Transactional(readOnly = true)
+    public List<MemberTeam> getMembersByTeamId(Long teamId) {
+        return memberTeamRepository.findWithMemberByTeamId(teamId);
+    }
+
+    // 특정 멤버가 속한 모든 팀 조회
+    @Transactional(readOnly = true)
+    public List<MemberTeam> getTeamsByMemberId(Long memberId) {
+        return memberTeamRepository.findWithTeamByMemberId(memberId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Long> getTeamIdsByMemberId(Long memberId) {
+        return memberTeamRepository.findWithTeamByMemberId(memberId)
+            .stream()
+            .map(mt -> mt.getTeam().getId())
+            .toList();
+    }
+
+    private void validateNotAlreadyJoined(Member member, Team team) {
+        if (memberTeamRepository.existsByMemberIdAndTeamId(member.getId(), team.getId())) {
+            throw ShowingException.from(ErrorCode.ALREADY_JOINED_TEAM);
+        }
+    }
+
+    private MemberTeam findById(Member member, Team team) {
+        return memberTeamRepository.findByMemberIdAndTeamId(member.getId(), team.getId())
+            .orElseThrow(() -> ShowingException.from(ErrorCode.NOT_MEMBER_OF_TEAM));
+    }
+}

--- a/src/main/java/com/saerok/showing/api/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/dto/request/PostCreateRequest.java
@@ -1,6 +1,7 @@
 package com.saerok.showing.api.domain.post.dto.request;
 
 import com.saerok.showing.api.domain.post.entity.PostType;
+import com.saerok.showing.api.domain.post.entity.PostVisibility;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -16,6 +17,10 @@ public class PostCreateRequest {
     @Size(max = 100, message = "게시글 제목은 최대 100자까지 입력할 수 있습니다.")
     @Schema(description = "게시글 제목", example = "순천만 습지 다녀온 썰")
     private String title;
+
+    @NotNull
+    @Schema(description = "게시글 가시성", example = "TEAM_ONLY")
+    private PostVisibility visibility;
 
     @NotNull
     @Schema(description = "게시글 타입", example = "NORMAL")

--- a/src/main/java/com/saerok/showing/api/domain/post/dto/request/PostUpdateRequest.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/dto/request/PostUpdateRequest.java
@@ -1,8 +1,10 @@
 package com.saerok.showing.api.domain.post.dto.request;
 
+import com.saerok.showing.api.domain.post.entity.PostVisibility;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -16,7 +18,15 @@ public class PostUpdateRequest {
     private String title;
 
     @NotNull
+    @Schema(description = "게시글 가시성", example = "VISIBLE_ALL")
+    private PostVisibility visibility;
+
+    @NotNull
     @Size(max = 1000, message = "게시글 내용은 최대 1000자까지 입력할 수 있습니다.")
     @Schema(description = "게시글 내용", example = "순천만 습지 처음 와봤는데 너무 재밌었어요~!!!!!!")
     private String content;
+
+    @NotNull
+    @Schema(description = "해시태그 목록", example = "[\"#순천만습지\", \"#두루미\"]")
+    private List<String> hashtags;
 }

--- a/src/main/java/com/saerok/showing/api/domain/post/entity/Post.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/entity/Post.java
@@ -52,6 +52,10 @@ public class Post extends BaseEntity {
     private String title;
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "visibility", nullable = false)
+    private PostVisibility visibility = PostVisibility.VISIBLE_ALL;
+
+    @Enumerated(EnumType.STRING)
     @Column(name = "post_type", nullable = false)
     private PostType postType;
 
@@ -74,6 +78,7 @@ public class Post extends BaseEntity {
         return Post.builder()
             .member(member)
             .title(request.getTitle())
+            .visibility(request.getVisibility())
             .postType(request.getPostType())
             .content(request.getContent())
             .postImages(files)
@@ -91,6 +96,8 @@ public class Post extends BaseEntity {
     public void update(PostUpdateRequest request) {
         this.title = request.getTitle();
         this.content = request.getContent();
+        this.visibility = request.getVisibility();
+        this.hashtags = request.getHashtags();
     }
 
     public void increaseLikeCount() {

--- a/src/main/java/com/saerok/showing/api/domain/post/entity/PostVisibility.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/entity/PostVisibility.java
@@ -1,0 +1,23 @@
+package com.saerok.showing.api.domain.post.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PostVisibility {
+
+    VISIBLE_ALL("VISIBLE_ALL", "전체 공개"),
+    TEAM_ONLY("TEAM_ONLY", "팀 전용");
+
+    private final String key;
+    private final String name;
+
+    public boolean isTeamOnly() {
+        return this == TEAM_ONLY;
+    }
+
+    public boolean isVisibleAll() {
+        return this == VISIBLE_ALL;
+    }
+}

--- a/src/main/java/com/saerok/showing/api/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/repository/PostRepository.java
@@ -12,52 +12,80 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-    // 1. 커서가 없을 때 (최초 요청) - 최신순
+    // 최신순 - 최초 페이지
     @Query("""
-            SELECT p FROM Post p
-            WHERE (:postType IS NULL OR p.postType = :postType)
-            ORDER BY p.createdAt DESC
+        SELECT DISTINCT p
+        FROM Post p
+        LEFT JOIN MemberTeam mt ON p.member.id = mt.member.id
+        WHERE (:postType IS NULL OR p.postType = :postType)
+          AND (
+              p.visibility = 'VISIBLE_ALL'
+              OR (p.visibility = 'TEAM_ONLY' AND mt.team.id IN :teamIds)
+          )
+        ORDER BY p.createdAt DESC
         """)
-    List<Post> findByPostTypeOrderByCreatedAtDesc(
-        @Param("postType") PostType postType
-    );
-
-    // 2. 커서가 있을 때 (이후 페이지 요청) - 최신순
-    @Query("""
-            SELECT p FROM Post p
-            WHERE (:postType IS NULL OR p.postType = :postType)
-              AND p.createdAt < :cursor
-            ORDER BY p.createdAt DESC
-        """)
-    List<Post> findByPostTypeAndCreatedAtBeforeOrderByCreatedAtDesc(
+    List<Post> findVisiblePostsOrderByCreatedAtDesc(
         @Param("postType") PostType postType,
-        @Param("cursor") LocalDateTime cursor
+        @Param("teamIds") List<Long> teamIds
     );
 
-    // 1. 커서가 없을 때 (인기순 기본 정렬) - 인기순
+    // 최신순 - 커서 페이징
     @Query("""
-            SELECT p FROM Post p
-            WHERE (:postType IS NULL OR p.postType = :postType)
-            ORDER BY p.likeCount DESC, p.createdAt DESC
+        SELECT DISTINCT p
+        FROM Post p
+        LEFT JOIN MemberTeam mt ON p.member.id = mt.member.id
+        WHERE (:postType IS NULL OR p.postType = :postType)
+          AND p.createdAt < :cursor
+          AND (
+              p.visibility = 'VISIBLE_ALL'
+              OR (p.visibility = 'TEAM_ONLY' AND mt.team.id IN :teamIds)
+          )
+        ORDER BY p.createdAt DESC
         """)
-    List<Post> findByPostTypeOrderByLikeCountDesc(
-        @Param("postType") PostType postType
+    List<Post> findVisiblePostsByCreatedAtBefore(
+        @Param("postType") PostType postType,
+        @Param("cursor") LocalDateTime cursor,
+        @Param("teamIds") List<Long> teamIds
     );
 
-    // 2. 커서가 있을 때 (likeCount, createdAt 기준 페이징) - 인기순
+    // 인기순 - 최초 페이지
     @Query("""
-            SELECT p FROM Post p
-            WHERE (:postType IS NULL OR p.postType = :postType)
-              AND (
-                p.likeCount < :likeCount
-                OR (p.likeCount = :likeCount AND p.createdAt < :createdAt)
-              )
-            ORDER BY p.likeCount DESC, p.createdAt DESC
+        SELECT DISTINCT p
+        FROM Post p
+        LEFT JOIN MemberTeam mt ON p.member.id = mt.member.id
+        WHERE (:postType IS NULL OR p.postType = :postType)
+          AND (
+              p.visibility = 'VISIBLE_ALL'
+              OR (p.visibility = 'TEAM_ONLY' AND mt.team.id IN :teamIds)
+          )
+        ORDER BY p.likeCount DESC, p.createdAt DESC
         """)
-    List<Post> findByPopularCursor(
+    List<Post> findVisiblePostsOrderByLikeCountDesc(
+        @Param("postType") PostType postType,
+        @Param("teamIds") List<Long> teamIds
+    );
+
+    // 인기순 - 커서 페이징
+    @Query("""
+        SELECT DISTINCT p
+        FROM Post p
+        LEFT JOIN MemberTeam mt ON p.member.id = mt.member.id
+        WHERE (:postType IS NULL OR p.postType = :postType)
+          AND (
+              p.likeCount < :likeCount
+              OR (p.likeCount = :likeCount AND p.createdAt < :createdAt)
+          )
+          AND (
+              p.visibility = 'VISIBLE_ALL'
+              OR (p.visibility = 'TEAM_ONLY' AND mt.team.id IN :teamIds)
+          )
+        ORDER BY p.likeCount DESC, p.createdAt DESC
+        """)
+    List<Post> findVisiblePostsByPopularCursor(
         @Param("postType") PostType postType,
         @Param("likeCount") int likeCount,
-        @Param("createdAt") LocalDateTime createdAt
+        @Param("createdAt") LocalDateTime createdAt,
+        @Param("teamIds") List<Long> teamIds
     );
 
     int countByMemberId(Long memberId);

--- a/src/main/java/com/saerok/showing/api/domain/post/service/PostService.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/service/PostService.java
@@ -2,6 +2,7 @@ package com.saerok.showing.api.domain.post.service;
 
 import com.saerok.showing.api.domain.comment.service.CommentCountProvider;
 import com.saerok.showing.api.domain.member.entity.Member;
+import com.saerok.showing.api.domain.memberTeam.service.MemberTeamService;
 import com.saerok.showing.api.domain.post.dto.request.PostCreateRequest;
 import com.saerok.showing.api.domain.post.dto.request.PostUpdateRequest;
 import com.saerok.showing.api.domain.post.dto.response.PostDetailResponse;
@@ -18,7 +19,9 @@ import com.saerok.showing.api.global.exception.ShowingException;
 import com.saerok.showing.api.global.file.entity.UploadedFile;
 import com.saerok.showing.api.global.file.service.FileService;
 import com.saerok.showing.api.global.pagination.cursorResult.CursorResult;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,10 +31,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class PostService {
 
     private final PostRepository postRepository;
-    private final LoginMemberProvider loginMemberProvider;
     private final FileService fileService;
-    private final PostPaginationStrategyFactory postPaginationStrategyFactory;
+    private final MemberTeamService memberTeamService;
+    private final LoginMemberProvider loginMemberProvider;
     private final CommentCountProvider commentCountProvider;
+    private final PostPaginationStrategyFactory postPaginationStrategyFactory;
 
     @Transactional
     public Long save(PostCreateRequest request) {
@@ -44,7 +48,10 @@ public class PostService {
 
     @Transactional(readOnly = true)
     public PostDetailResponse getPostDetails(Long postId) {
+        Member currentMember = loginMemberProvider.getCurrentLoginMember();
+        List<Long> teamIds = memberTeamService.getTeamIdsByMemberId(currentMember.getId());
         Post post = findById(postId);
+        validatePostVisibility(post, teamIds);
         int commentCount = commentCountProvider.getCount(postId);
         return PostDetailResponse.toDto(post, commentCount);
     }
@@ -56,8 +63,10 @@ public class PostService {
         String cursorRaw,
         int limit
     ) {
+        Member currentMember = loginMemberProvider.getCurrentLoginMember();
+        List<Long> teamIds = memberTeamService.getTeamIdsByMemberId(currentMember.getId());
         PostPaginationStrategy strategy = postPaginationStrategyFactory.getStrategy(sortType);
-        return strategy.getCursorResult(postType, cursorRaw, limit, commentCountProvider);
+        return strategy.getCursorResult(postType, cursorRaw, limit, teamIds, commentCountProvider);
     }
 
     @Transactional
@@ -76,6 +85,16 @@ public class PostService {
         post.validateOwner(member);
         postRepository.delete(post);
         return postId;
+    }
+
+    private void validatePostVisibility(Post post, List<Long> viewerTeamIds) {
+        if (post.getVisibility().isTeamOnly()) {
+            Set<Long> authorTeamIds = new HashSet<>(memberTeamService.getTeamIdsByMemberId(post.getMember().getId()));
+            viewerTeamIds.stream()
+                .filter(authorTeamIds::contains)
+                .findAny()
+                .orElseThrow(() -> ShowingException.from(ErrorCode.FORBIDDEN));
+        }
     }
 
     public int getPostCount() {

--- a/src/main/java/com/saerok/showing/api/domain/post/service/pagination/LatestPostPaginationStrategy.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/service/pagination/LatestPostPaginationStrategy.java
@@ -40,25 +40,27 @@ public class LatestPostPaginationStrategy implements PostPaginationStrategy {
     }
 
     @Override
-    public List<Post> paginate(PostType postType, Object cursor, int limit) {
+    public List<Post> paginate(PostType postType, Object cursor, int limit, List<Long> teamIds) {
         LocalDateTime cursorTime = (cursor instanceof CreatedAtCursor c) ? c.createdAt() : null;
         return (
             cursorTime == null
-                ? postRepository.findByPostTypeOrderByCreatedAtDesc(postType)
-                : postRepository.findByPostTypeAndCreatedAtBeforeOrderByCreatedAtDesc(postType, cursorTime)
+                ? postRepository.findVisiblePostsOrderByCreatedAtDesc(postType, teamIds)
+                : postRepository.findVisiblePostsByCreatedAtBefore(postType, cursorTime, teamIds)
         ).stream()
             .limit(limit + 1)
             .toList();
     }
 
+    @Override
     public CursorResult<PostSummaryResponse> getCursorResult(
         PostType postType,
         String cursorRaw,
         int limit,
+        List<Long> teamIds,
         CommentCountProvider commentCountProvider
     ) {
         CreatedAtCursor cursor = (CreatedAtCursor) parseCursor(cursorRaw);
-        List<Post> posts = paginate(postType, cursor, limit);
+        List<Post> posts = paginate(postType, cursor, limit, teamIds);
         List<PostSummaryResponse> responses = posts.stream()
             .map(post -> PostSummaryResponse.toDto(post, commentCountProvider.getCount(post.getId())))
             .toList();

--- a/src/main/java/com/saerok/showing/api/domain/post/service/pagination/PopularPostPaginationStrategy.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/service/pagination/PopularPostPaginationStrategy.java
@@ -43,15 +43,20 @@ public class PopularPostPaginationStrategy implements PostPaginationStrategy {
     }
 
     @Override
-    public List<Post> paginate(PostType postType, Object cursor, int limit) {
-        if (cursor instanceof PopularCursor c) {
-            return postRepository.findByPopularCursor(postType, c.likeCount(), c.createdAt()).stream()
+    public List<Post> paginate(PostType postType, Object cursor, int limit, List<Long> teamIds) {
+        if (cursor == null) {
+            return postRepository.findVisiblePostsOrderByLikeCountDesc(postType, teamIds)
+                .stream()
                 .limit(limit + 1)
                 .toList();
         }
-        return postRepository.findByPostTypeOrderByLikeCountDesc(postType).stream()
-            .limit(limit + 1)
-            .toList();
+        if (cursor instanceof PopularCursor c) {
+            return postRepository.findVisiblePostsByPopularCursor(postType, c.likeCount(), c.createdAt(), teamIds)
+                .stream()
+                .limit(limit + 1)
+                .toList();
+        }
+        throw ShowingException.from(ErrorCode.INVALID_CURSOR_FORMAT);
     }
 
     @Override
@@ -59,10 +64,11 @@ public class PopularPostPaginationStrategy implements PostPaginationStrategy {
         PostType postType,
         String cursorRaw,
         int limit,
+        List<Long> teamIds,
         CommentCountProvider commentCountProvider
     ) {
         PopularCursor cursor = (PopularCursor) parseCursor(cursorRaw);
-        List<Post> posts = paginate(postType, cursor, limit);
+        List<Post> posts = paginate(postType, cursor, limit, teamIds);
         List<PostSummaryResponse> responses = posts.stream()
             .map(post -> PostSummaryResponse.toDto(post, commentCountProvider.getCount(post.getId())))
             .toList();

--- a/src/main/java/com/saerok/showing/api/domain/post/service/pagination/PostPaginationStrategy.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/service/pagination/PostPaginationStrategy.java
@@ -14,12 +14,13 @@ public interface PostPaginationStrategy {
 
     Object parseCursor(String rawCursor);
 
-    List<Post> paginate(PostType postType, Object cursor, int limit);
+    List<Post> paginate(PostType postType, Object cursor, int limit, List<Long> teamIds);
 
     CursorResult<PostSummaryResponse> getCursorResult(
         PostType postType,
         String rawCursor,
         int limit,
+        List<Long> teamIds,
         CommentCountProvider commentCountProvider
     );
 }

--- a/src/main/java/com/saerok/showing/api/domain/team/controller/TeamController.java
+++ b/src/main/java/com/saerok/showing/api/domain/team/controller/TeamController.java
@@ -84,13 +84,15 @@ public class TeamController {
         summary = "팀 내 팀원 목록 조회",
         description = """
             [모든 Role 가능] 팀에 속한 팀원들을 조회합니다.<br>
-            먼저 가입한 순으로 정렬되며, 팀리더가 제일먼저입니다.
+            먼저 가입한 순으로 정렬되며, 팀리더가 가장 먼저 조회됩니다.
             """
     )
     @PreAuthorize("hasRole('MEMBER')")
-    @GetMapping("/members")
-    public ApiResponse<List<TeamMemberResponse>> getMyTeamMembers() {
-        List<TeamMemberResponse> members = teamService.getMyTeamMembers();
+    @GetMapping("/{teamId}/members")
+    public ApiResponse<List<TeamMemberResponse>> getTeamMembers(
+        @PathVariable Long teamId
+    ) {
+        List<TeamMemberResponse> members = teamService.getTeamMembers(teamId);
         return ApiResponse.success(members);
     }
 

--- a/src/main/java/com/saerok/showing/api/domain/team/dto/response/TeamMemberResponse.java
+++ b/src/main/java/com/saerok/showing/api/domain/team/dto/response/TeamMemberResponse.java
@@ -12,15 +12,15 @@ public class TeamMemberResponse {
 
     private Long memberId;
 
-    private String name;
+    private String memberName;
 
     private String profileImage;
 
-    public static TeamMemberResponse toDto(Member member) {
+    public static TeamMemberResponse toDto(Member member, Long teamId) {
         return TeamMemberResponse.builder()
-            .teamId(member.getTeam().getId())
+            .teamId(teamId)
             .memberId(member.getId())
-            .name(member.getName())
+            .memberName(member.getName())
             .profileImage(member.getProfileImage())
             .build();
     }

--- a/src/main/java/com/saerok/showing/api/domain/team/entity/Team.java
+++ b/src/main/java/com/saerok/showing/api/domain/team/entity/Team.java
@@ -2,18 +2,15 @@ package com.saerok.showing.api.domain.team.entity;
 
 import com.saerok.showing.api.domain.team.dto.request.TeamCreateRequest;
 import com.saerok.showing.api.domain.member.entity.Member;
+import com.saerok.showing.api.global.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,7 +25,7 @@ import lombok.Setter;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "team")
-public class Team {
+public class Team extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -45,10 +42,6 @@ public class Team {
     @JoinColumn(name = "leader_id", nullable = false)
     private Member leader;
 
-    @Builder.Default
-    @OneToMany(mappedBy = "team", fetch = FetchType.LAZY)
-    private List<Member> members = new ArrayList<>();
-
     public static Team toEntity(TeamCreateRequest request, Member leader, String encryptedPassword) {
         return Team.builder()
             .name(request.getName())
@@ -59,10 +52,5 @@ public class Team {
 
     public boolean isLeader(Member member) {
         return leader != null && leader.getId().equals(member.getId());
-    }
-
-    public void addMember(Member member) {
-        members.add(member);
-        member.setTeam(this);
     }
 }

--- a/src/main/java/com/saerok/showing/api/domain/team/repository/TeamRepository.java
+++ b/src/main/java/com/saerok/showing/api/domain/team/repository/TeamRepository.java
@@ -3,15 +3,10 @@ package com.saerok.showing.api.domain.team.repository;
 import com.saerok.showing.api.domain.team.entity.Team;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface TeamRepository extends JpaRepository<Team, Long> {
-
-    @Query("SELECT t FROM Team t JOIN FETCH t.members WHERE t.id = :teamId")
-    Optional<Team> findByIdWithMembers(@Param("teamId") Long teamId);
 
     Optional<Team> findByName(String name);
 

--- a/src/main/java/com/saerok/showing/api/domain/team/service/TeamService.java
+++ b/src/main/java/com/saerok/showing/api/domain/team/service/TeamService.java
@@ -2,6 +2,8 @@ package com.saerok.showing.api.domain.team.service;
 
 import com.saerok.showing.api.domain.member.entity.Member;
 import com.saerok.showing.api.domain.member.repository.MemberRepository;
+import com.saerok.showing.api.domain.memberTeam.entity.MemberTeam;
+import com.saerok.showing.api.domain.memberTeam.service.MemberTeamService;
 import com.saerok.showing.api.domain.team.dto.request.TeamCreateRequest;
 import com.saerok.showing.api.domain.team.dto.request.TeamJoinRequest;
 import com.saerok.showing.api.domain.team.dto.response.TeamMemberResponse;
@@ -23,30 +25,27 @@ public class TeamService {
 
     private final TeamRepository teamRepository;
     private final MemberRepository memberRepository;
+    private final MemberTeamService memberTeamService;
     private final BCryptPasswordEncoder passwordEncoder;
     private final LoginMemberProvider loginMemberProvider;
 
     @Transactional
     public Long save(TeamCreateRequest request) {
         Member member = loginMemberProvider.getCurrentLoginMember();
-        validateNotAlreadyJoined(member);
         validateUniqueTeamName(request.getName());
         String encodedPassword = passwordEncoder.encode(request.getPassword());
         Team team = Team.toEntity(request, member, encodedPassword);
         teamRepository.save(team);
-        team.addMember(member);
-        memberRepository.save(member);
+        memberTeamService.addMemberToTeam(member, team);
         return team.getId();
     }
 
     @Transactional
     public Long joinTeam(TeamJoinRequest request) {
         Member member = loginMemberProvider.getCurrentLoginMember();
-        validateNotAlreadyJoined(member);
         Team team = findByName(request.getName());
         validateTeamPassword(team, request.getPassword());
-        member.joinTeam(team);
-        memberRepository.save(member);
+        memberTeamService.addMemberToTeam(member, team);
         return team.getId();
     }
 
@@ -54,23 +53,22 @@ public class TeamService {
     public Long leaveTeam(Long teamId) {
         Member member = loginMemberProvider.getCurrentLoginMember();
         Team team = findById(teamId);
-        validateIsMemberOfTeam(member, team);
         if (team.isLeader(member)) {
             deleteTeamAsLeader(team);
         } else {
-            leaveTeamAsMember(member);
+            memberTeamService.removeMemberFromTeam(member, team);
         }
         return teamId;
     }
 
     @Transactional(readOnly = true)
-    public List<TeamMemberResponse> getMyTeamMembers() {
-        Member member = loginMemberProvider.getCurrentLoginMember();
-        Team team = getTeamOfCurrentMember();
-        List<Member> members = team.getMembers();
-        return members.stream()
+    public List<TeamMemberResponse> getTeamMembers(Long teamId) {
+        Member currentMember = loginMemberProvider.getCurrentLoginMember();
+        validateIsMemberOfTeam(currentMember, teamId);
+        return memberTeamService.getMembersByTeamId(teamId).stream()
+            .map(MemberTeam::getMember)
             .sorted(Comparator.comparing(Member::getCreatedAt))
-            .map(TeamMemberResponse::toDto)
+            .map(member -> TeamMemberResponse.toDto(member, teamId))
             .toList();
     }
 
@@ -78,8 +76,10 @@ public class TeamService {
     public Long delete(Long teamId) {
         Team team = findById(teamId);
         assertLeader(team);
-        List<Member> members = team.getMembers();
-        removeAllMembersFromTeam(team);
+        List<MemberTeam> members = memberTeamService.getMembersByTeamId(teamId);
+        for (MemberTeam mt : members) {
+            memberTeamService.removeMemberFromTeam(mt.getMember(), team);
+        }
         teamRepository.deleteById(teamId);
         return teamId;
     }
@@ -94,24 +94,9 @@ public class TeamService {
             .orElseThrow(() -> ShowingException.from(ErrorCode.TEAM_NOT_FOUND));
     }
 
-    private Team getTeamOfCurrentMember() {
-        Member currentMember = loginMemberProvider.getCurrentLoginMember();
-        if (currentMember.getTeam() == null) {
-            throw ShowingException.from(ErrorCode.NOT_MEMBER_OF_TEAM);
-        }
-        return teamRepository.findByIdWithMembers(currentMember.getTeam().getId())
-            .orElseThrow(() -> ShowingException.from(ErrorCode.TEAM_NOT_FOUND));
-    }
-
     private void validateUniqueTeamName(String name) {
         if (teamRepository.existsByName(name)) {
             throw ShowingException.from(ErrorCode.DUPLICATE_TEAM_NAME);
-        }
-    }
-
-    private void validateNotAlreadyJoined(Member member) {
-        if (member.getTeam() != null) {
-            throw ShowingException.from(ErrorCode.ALREADY_JOINED_TEAM);
         }
     }
 
@@ -121,8 +106,10 @@ public class TeamService {
         }
     }
 
-    private void validateIsMemberOfTeam(Member member, Team team) {
-        if (member.getTeam() == null || !team.getId().equals(member.getTeam().getId())) {
+    private void validateIsMemberOfTeam(Member member, Long teamId) {
+        boolean isInTeam = memberTeamService.getTeamsByMemberId(member.getId()).stream()
+            .anyMatch(mt -> mt.getTeam().getId().equals(teamId));
+        if (!isInTeam) {
             throw ShowingException.from(ErrorCode.NOT_MEMBER_OF_TEAM);
         }
     }
@@ -135,19 +122,10 @@ public class TeamService {
     }
 
     private void deleteTeamAsLeader(Team team) {
-        for (Member m : team.getMembers()) {
-            m.leaveTeam();
-            memberRepository.save(m);
+        List<MemberTeam> members = memberTeamService.getMembersByTeamId(team.getId());
+        for (MemberTeam mt : members) {
+            memberTeamService.removeMemberFromTeam(mt.getMember(), team);
         }
         teamRepository.delete(team);
-    }
-
-    private void leaveTeamAsMember(Member member) {
-        member.leaveTeam();
-        memberRepository.save(member);
-    }
-
-    private void removeAllMembersFromTeam(Team team) {
-        team.getMembers().forEach(member -> member.setTeam(null));
     }
 }

--- a/src/main/java/com/saerok/showing/api/global/auth/service/CustomOAuth2MemberService.java
+++ b/src/main/java/com/saerok/showing/api/global/auth/service/CustomOAuth2MemberService.java
@@ -59,7 +59,6 @@ public class CustomOAuth2MemberService extends DefaultOAuth2UserService {
             .profileImage(oAuth2Response.getProfileImage())
             .role(Role.MEMBER)
             .loginType(LoginType.from(oAuth2Response.getProvider()))
-            .team(null)
             .build();
     }
 

--- a/src/main/resources/data/05-post.sql
+++ b/src/main/resources/data/05-post.sql
@@ -3,32 +3,32 @@
 TRUNCATE TABLE post RESTART IDENTITY CASCADE;
 
 -- 게시글 더미 데이터 5개 삽입
-INSERT INTO post (title, content, post_type, like_count, created_at, updated_at, member_id)
+INSERT INTO post (title, content, post_type, visibility, like_count, created_at, updated_at, member_id)
 VALUES
     -- 김민상 (1)
     ('흑두루미, 실제로 보니까 너무 감동이에요',
      '순천만 갈대밭에서 이른 아침에 흑두루미 무리를 봤어요. 조용히 울음소리 듣고 있으니 마음이 차분해졌어요. 겨울 새벽엔 꼭 방한 잘 하고 가세요!',
-     'NORMAL', 0, NOW(), NOW(), 1),
+     'NORMAL', 'VISIBLE_ALL', 0, NOW(), NOW(), 1),
 
     -- 홍원택 (2)
     ('우포늪에서 만난 따오기, 눈물이 날 뻔했어요',
      '사진으로만 보던 따오기를 진짜 보니 감회가 남다르더라고요. 하얀 날개가 햇빛에 반짝이는 모습이 아직도 눈에 아른거려요.',
-     'NORMAL', 0, NOW(), NOW(), 2),
+     'NORMAL', 'VISIBLE_ALL', 0, NOW(), NOW(), 2),
 
     -- 박성민 (3)
     ('가창오리 군무는 진짜 꼭 봐야 합니다',
      '서천 금강하구 제방 근처에서 해질 무렵 가창오리 떼를 봤어요. 하늘을 가득 메우는데 숨이 멎는 줄 알았어요. 영상 찍었는데 소름...!',
-     'NORMAL', 0, NOW(), NOW(), 3),
+     'NORMAL', 'VISIBLE_ALL', 0, NOW(), NOW(), 3),
 
     -- 김루시아 (4)
     ('백령도 검은머리물떼새, 드디어 직접 봤어요 🖤',
      '사진으로만 보던 그 새를... 진짜 갯벌에서 만났어요. 생각보다 작고 귀엽고, 움직임도 섬세해요. 백령도 가는 길은 멀지만 그럴만한 가치 있어요!',
-     'NORMAL', 0, NOW(), NOW(), 4),
+     'NORMAL', 'VISIBLE_ALL', 0, NOW(), NOW(), 4),
 
     -- 김민상 (1) 두 번째
     ('시화호 갈대길에서 만난 도요새 이야기',
      '따뜻한 봄날, 시화호 갈대길을 걷다가 도요새 무리를 만났어요. 부리가 길고 바쁘게 움직이던 모습이 인상적이었어요. 한참을 망원경으로 관찰했네요.',
-     'NORMAL', 0, NOW(), NOW(), 1);
+     'NORMAL', 'VISIBLE_ALL', 0, NOW(), NOW(), 1);
 
 -- 시퀀스 재설정
 SELECT setval('post_post_id_seq', (SELECT MAX(post_id) FROM post));


### PR DESCRIPTION
## ⭐️ Overview

> #59  

회원-팀 관계를 다대다 구조로 리팩토링하고, 게시글에 가시성(`visibility`) 필드를 추가했습니다.

## 🔧 Tasks

- `MemberTeam` 엔티티 도입 → 회원-팀 중간 테이블로 다대다 관계 해소
- `Member`, `Team` 엔티티 리팩토링 (기존 1:N 구조 제거)
- `Post` 엔티티에 `visibility` 필드(`VISIBLE_ALL`, `TEAM_ONLY`) 추가
- `PostCreateRequest`, `PostUpdateRequest` DTO에 `visibility` 반영
- 게시글 생성/수정/조회 시 가시성 정책 검증 로직 적용

## 📝 Additional Notes

- 인기순/최신순 페이지네이션 전략에 가시성 정책을 반영 완료했습니다.

## 📸 Screenshot

- (추후 추가 예정)