### PR TITLE
refactor: 루트 내 장소 조회 시 TourAPI를 위한 필드들 추가

### DIFF
--- a/src/main/java/com/saerok/showing/api/domain/comment/dto/response/CommentResponse.java
+++ b/src/main/java/com/saerok/showing/api/domain/comment/dto/response/CommentResponse.java
@@ -24,8 +24,8 @@ public class CommentResponse {
         return CommentResponse.builder()
             .id(comment.getId())
             .postId(comment.getPost().getId())
-            .writer(comment.getPost().getMember().getName())
-            .writerProfileImage(comment.getPost().getMember().getProfileImage())
+            .writer(comment.getMember().getName())
+            .writerProfileImage(comment.getMember().getProfileImage())
             .comment(comment.getComment())
             .likeCount(comment.getLikeCount())
             .build();

--- a/src/main/java/com/saerok/showing/api/domain/post/controller/PostController.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/controller/PostController.java
@@ -37,7 +37,8 @@ public class PostController {
         description = """
             [모든 Role 가능] 게시글을 작성합니다.<br>
             요청 본문에는 제목, 내용, 게시글 타입, 게시글 이미지(리스트), 해시태그(리스트)가 포함됩니다.<br>
-            게시글 이미지는 "/api/v1/file/post"를 이용하여 얻은 fileUrl값들을 입력해주세요.
+            게시글 이미지는 "/api/v1/file/post"를 이용하여 얻은 fileUrl값들을 입력해주세요.<br>
+            전체 공개는 VISIBLE_ALL, 팀만 공개는 TEAM_ONLY로 visibility를 지정해주세요.
             """
     )
     @PreAuthorize("hasRole('MEMBER')")

--- a/src/main/java/com/saerok/showing/api/domain/routePlace/dto/request/RoutePlaceCreateRequest.java
+++ b/src/main/java/com/saerok/showing/api/domain/routePlace/dto/request/RoutePlaceCreateRequest.java
@@ -26,4 +26,12 @@ public class RoutePlaceCreateRequest {
     @NotNull
     @Schema(description = "해당 일자 내 장소 방문 순서(M번쨰)입니다. M은 1~30의 값입니다.", example = "1")
     private int orderInDay;
+
+    @NotNull
+    @Schema(description = "TourAPI 조회용 pk값 1", example = "1")
+    private String contentId;
+
+    @NotNull
+    @Schema(description = "TourAPI 조회용 pk값 2", example = "1")
+    private String contentTypeId;
 }

--- a/src/main/java/com/saerok/showing/api/domain/routePlace/dto/request/RoutePlaceUpdateRequest.java
+++ b/src/main/java/com/saerok/showing/api/domain/routePlace/dto/request/RoutePlaceUpdateRequest.java
@@ -29,4 +29,10 @@ public class RoutePlaceUpdateRequest {
 
     @Schema(description = "장소 이름", example = "엘리시안 강촌 리조트")
     private String placeName;
+
+    @Schema(description = "TourAPI 조회용 pk값 1", example = "1")
+    private String contentId;
+
+    @Schema(description = "TourAPI 조회용 pk값 2", example = "1")
+    private String contentTypeId;
 }

--- a/src/main/java/com/saerok/showing/api/domain/routePlace/dto/response/RoutePlaceBoxResponse.java
+++ b/src/main/java/com/saerok/showing/api/domain/routePlace/dto/response/RoutePlaceBoxResponse.java
@@ -1,6 +1,7 @@
 package com.saerok.showing.api.domain.routePlace.dto.response;
 
 import com.saerok.showing.api.domain.routePlace.entity.RoutePlace;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -14,6 +15,10 @@ public class RoutePlaceBoxResponse {
 
     private int orderInDay;
 
+    private String contentId;
+
+    private String contentTypeId;
+
 //    private String imageUrl;
 
     public static RoutePlaceBoxResponse toDto(RoutePlace routePlace) {
@@ -21,6 +26,8 @@ public class RoutePlaceBoxResponse {
             .title(routePlace.getPlaceName())
             .dayNumber(routePlace.getDayNumber())
             .orderInDay(routePlace.getOrderInDay())
+            .contentId(routePlace.getContentId())
+            .contentTypeId(routePlace.getContentTypeId())
 //            .imageUrl(routePlace.getPlace().getPlaceImage())
             .build();
     }

--- a/src/main/java/com/saerok/showing/api/domain/routePlace/entity/RoutePlace.java
+++ b/src/main/java/com/saerok/showing/api/domain/routePlace/entity/RoutePlace.java
@@ -49,12 +49,20 @@ public class RoutePlace extends BaseEntity {
     @Column(name = "order_in_day", nullable = false)
     private int orderInDay;
 
+    @Column(name = "content_id", nullable = false)
+    private String contentId;
+
+    @Column(name = "content_type_id", nullable = false)
+    private String contentTypeId;
+
     public static RoutePlace toEntity(RoutePlaceCreateRequest request, Route route, String PlaceName) {
         return RoutePlace.builder()
             .route(route)
             .placeName(PlaceName)
             .dayNumber(request.getDayNumber())
             .orderInDay(request.getOrderInDay())
+            .contentId(request.getContentId())
+            .contentTypeId(request.getContentTypeId())
             .build();
     }
 


### PR DESCRIPTION
## ⭐️ Overview

> #63

루트 내 장소 조회 시 TourAPI를 위한 pk 필드 2개를 추가했습니다.
일부 버그를 수정했습니다.

## 🔧 Tasks

- 루트 내 장소 필드 2개(`contentId`, `contentTypeId`) 추가

## 📸 Screenshot

### 루트 내 장소 추가
<img width="650" alt="루트 내 장소 추가" src="https://github.com/user-attachments/assets/86f0e5f9-7e5f-4b0d-9339-8795efdc3a85" />

### 루트 내 장소 수정
<img width="650" alt="루트 내 장소 수정" src="https://github.com/user-attachments/assets/1189a92a-faa6-44ed-ad9e-76ca3e13f0d9" />

### 루트 내 장소 조회
<img width="650" alt="루트 내 장소 조회" src="https://github.com/user-attachments/assets/e795add2-7827-44bb-a716-bc114ce25ccd" />

