### PR TITLE
refactor: 좋아요 유무 확인 필드 추가

### DIFF
--- a/src/main/java/com/saerok/showing/api/domain/comment/dto/response/CommentResponse.java
+++ b/src/main/java/com/saerok/showing/api/domain/comment/dto/response/CommentResponse.java
@@ -20,7 +20,9 @@ public class CommentResponse {
 
     private int likeCount;
 
-    public static CommentResponse toDto(Comment comment) {
+    private boolean isLiked;
+
+    public static CommentResponse toDto(Comment comment, boolean isLiked) {
         return CommentResponse.builder()
             .id(comment.getId())
             .postId(comment.getPost().getId())
@@ -28,6 +30,7 @@ public class CommentResponse {
             .writerProfileImage(comment.getMember().getProfileImage())
             .comment(comment.getComment())
             .likeCount(comment.getLikeCount())
+            .isLiked(isLiked)
             .build();
     }
 }

--- a/src/main/java/com/saerok/showing/api/domain/comment/service/CommentService.java
+++ b/src/main/java/com/saerok/showing/api/domain/comment/service/CommentService.java
@@ -1,5 +1,6 @@
 package com.saerok.showing.api.domain.comment.service;
 
+import com.saerok.showing.api.domain.like.service.LikeReadService;
 import com.saerok.showing.api.domain.member.entity.Member;
 import com.saerok.showing.api.domain.comment.dto.request.CommentCreateRequest;
 import com.saerok.showing.api.domain.comment.dto.response.CommentResponse;
@@ -23,6 +24,7 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final LoginMemberProvider loginMemberProvider;
     private final PostService postService;
+    private final LikeReadService likeReadService;
 
     @Transactional
     public Long create(Long postId, CommentCreateRequest request) {
@@ -35,9 +37,13 @@ public class CommentService {
 
     @Transactional(readOnly = true)
     public List<CommentResponse> getCommentsByPostId(Long postId) {
+        Member currentMember = loginMemberProvider.getCurrentLoginMember();
         List<Comment> comments = commentRepository.findAllByPostId(postId);
         return comments.stream()
-            .map(CommentResponse::toDto)
+            .map(comment -> {
+                boolean isLiked = likeReadService.isCommentLiked(currentMember, comment.getId());
+                return CommentResponse.toDto(comment, isLiked);
+            })
             .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/saerok/showing/api/domain/like/controller/LikeController.java
+++ b/src/main/java/com/saerok/showing/api/domain/like/controller/LikeController.java
@@ -25,7 +25,7 @@ public class LikeController {
         summary = "좋아요 토글 (게시글/댓글)",
         description = """
             [모든 Role 가능] 좋아요 토글입니다.<br>
-            좋아요 대상은 POST(게시글), COMMENT(댓글), ROUTE(여행 경로) 3가지입니다.<br>
+            좋아요 대상은 POST(게시글), COMMENT(댓글), ROUTE(여행 경로), POLL(투표 그 자체), POLL_ROUTE(투표 내 여행경로) 5가지입니다.<br>
             좋아요 된 대상을 다시 토글하게 되면 좋아요가 취소됩니다.<br>
             true 반환인 경우 좋아요 등록, false 반환은 좋아요 취소입니다.
             """

--- a/src/main/java/com/saerok/showing/api/domain/like/service/LikeReadService.java
+++ b/src/main/java/com/saerok/showing/api/domain/like/service/LikeReadService.java
@@ -1,0 +1,25 @@
+package com.saerok.showing.api.domain.like.service;
+
+import com.saerok.showing.api.domain.like.entity.LikeTargetType;
+import com.saerok.showing.api.domain.like.repository.LikeRepository;
+import com.saerok.showing.api.domain.member.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class LikeReadService {
+
+    private final LikeRepository likeRepository;
+
+    @Transactional(readOnly = true)
+    public boolean isPostLiked(Member member, Long postId) {
+        return likeRepository.findByMemberAndTargetIdAndTargetType(member, postId, LikeTargetType.POST).isPresent();
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isCommentLiked(Member member, Long commentId) {
+        return likeRepository.findByMemberAndTargetIdAndTargetType(member, commentId, LikeTargetType.COMMENT).isPresent();
+    }
+}

--- a/src/main/java/com/saerok/showing/api/domain/post/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/dto/response/PostDetailResponse.java
@@ -34,11 +34,13 @@ public class PostDetailResponse {
 
     private int commentCount;
 
+    private boolean isLiked;
+
     private LocalDateTime createdAt;
 
     private LocalDateTime updatedAt;
 
-    public static PostDetailResponse toDto(Post post, int commentCount) {
+    public static PostDetailResponse toDto(Post post, int commentCount, boolean isLiked) {
         List<UploadedFile> files = post.getPostImages();
         return PostDetailResponse.builder()
             .id(post.getId())
@@ -51,6 +53,7 @@ public class PostDetailResponse {
             .postType(post.getPostType())
             .likeCount(post.getLikeCount())
             .commentCount(commentCount)
+            .isLiked(isLiked)
             .createdAt(post.getCreatedAt())
             .updatedAt(post.getUpdatedAt())
             .build();

--- a/src/main/java/com/saerok/showing/api/domain/post/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/dto/response/PostDetailResponse.java
@@ -2,6 +2,7 @@ package com.saerok.showing.api.domain.post.dto.response;
 
 import com.saerok.showing.api.domain.post.entity.Post;
 import com.saerok.showing.api.domain.post.entity.PostType;
+import com.saerok.showing.api.domain.post.entity.PostVisibility;
 import com.saerok.showing.api.global.file.dto.ExternalFileResponse;
 import com.saerok.showing.api.global.file.entity.UploadedFile;
 import java.time.LocalDateTime;
@@ -25,6 +26,8 @@ public class PostDetailResponse {
 
     private List<ExternalFileResponse> postImages;
 
+    private PostVisibility visibility;
+
     private PostType postType;
 
     private int likeCount;
@@ -44,6 +47,7 @@ public class PostDetailResponse {
             .title(post.getTitle())
             .content(post.getContent())
             .postImages(ExternalFileResponse.toListDto(files))
+            .visibility(post.getVisibility())
             .postType(post.getPostType())
             .likeCount(post.getLikeCount())
             .commentCount(commentCount)

--- a/src/main/java/com/saerok/showing/api/domain/post/dto/response/PostSummaryResponse.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/dto/response/PostSummaryResponse.java
@@ -2,6 +2,7 @@ package com.saerok.showing.api.domain.post.dto.response;
 
 import com.saerok.showing.api.domain.post.entity.Post;
 import com.saerok.showing.api.domain.post.entity.PostType;
+import com.saerok.showing.api.domain.post.entity.PostVisibility;
 import com.saerok.showing.api.global.file.dto.ExternalFileResponse;
 import com.saerok.showing.api.global.file.entity.UploadedFile;
 import com.saerok.showing.api.global.pagination.provider.CreatedAtProvider;
@@ -26,6 +27,8 @@ public class PostSummaryResponse implements CreatedAtProvider, PopularProvider {
     private String content;
 
     private ExternalFileResponse postImage;
+
+    private PostVisibility visibility;
 
     private PostType postType;
 
@@ -58,6 +61,7 @@ public class PostSummaryResponse implements CreatedAtProvider, PopularProvider {
             .writerProfileImage(post.getMember().getProfileImage())
             .content(post.getContent())
             .postImage(imageDto)
+            .visibility(post.getVisibility())
             .postType(post.getPostType())
             .likeCount(post.getLikeCount())
             .commentCount(commentCount)

--- a/src/main/java/com/saerok/showing/api/domain/post/dto/response/PostSummaryResponse.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/dto/response/PostSummaryResponse.java
@@ -36,6 +36,8 @@ public class PostSummaryResponse implements CreatedAtProvider, PopularProvider {
 
     private int commentCount;
 
+    private boolean isLiked;
+
     private LocalDateTime createdAt;
 
     @Override
@@ -48,7 +50,7 @@ public class PostSummaryResponse implements CreatedAtProvider, PopularProvider {
         return createdAt;
     }
 
-    public static PostSummaryResponse toDto(Post post, int commentCount) {
+    public static PostSummaryResponse toDto(Post post, int commentCount, boolean isLiked) {
         Optional<UploadedFile> firstFile = post.getPostImages().stream().findFirst();
         ExternalFileResponse imageDto = firstFile
             .map(ExternalFileResponse::toDto)
@@ -65,6 +67,7 @@ public class PostSummaryResponse implements CreatedAtProvider, PopularProvider {
             .postType(post.getPostType())
             .likeCount(post.getLikeCount())
             .commentCount(commentCount)
+            .isLiked(isLiked)
             .createdAt(post.getCreatedAt())
             .build();
     }

--- a/src/main/java/com/saerok/showing/api/domain/post/service/PostService.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/service/PostService.java
@@ -1,6 +1,7 @@
 package com.saerok.showing.api.domain.post.service;
 
 import com.saerok.showing.api.domain.comment.service.CommentCountProvider;
+import com.saerok.showing.api.domain.like.service.LikeReadService;
 import com.saerok.showing.api.domain.member.entity.Member;
 import com.saerok.showing.api.domain.memberTeam.service.MemberTeamService;
 import com.saerok.showing.api.domain.post.dto.request.PostCreateRequest;
@@ -32,6 +33,7 @@ public class PostService {
 
     private final PostRepository postRepository;
     private final FileService fileService;
+    private final LikeReadService likeReadService;
     private final MemberTeamService memberTeamService;
     private final LoginMemberProvider loginMemberProvider;
     private final CommentCountProvider commentCountProvider;
@@ -53,7 +55,8 @@ public class PostService {
         Post post = findById(postId);
         validatePostVisibility(post, teamIds);
         int commentCount = commentCountProvider.getCount(postId);
-        return PostDetailResponse.toDto(post, commentCount);
+        boolean isLiked = likeReadService.isPostLiked(currentMember, postId);
+        return PostDetailResponse.toDto(post, commentCount, isLiked);
     }
 
     @Transactional(readOnly = true)
@@ -66,7 +69,8 @@ public class PostService {
         Member currentMember = loginMemberProvider.getCurrentLoginMember();
         List<Long> teamIds = memberTeamService.getTeamIdsByMemberId(currentMember.getId());
         PostPaginationStrategy strategy = postPaginationStrategyFactory.getStrategy(sortType);
-        return strategy.getCursorResult(postType, cursorRaw, limit, teamIds, commentCountProvider);
+        return strategy.getCursorResult(postType, cursorRaw, limit, teamIds, commentCountProvider, likeReadService,
+            currentMember);
     }
 
     @Transactional

--- a/src/main/java/com/saerok/showing/api/domain/post/service/pagination/LatestPostPaginationStrategy.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/service/pagination/LatestPostPaginationStrategy.java
@@ -1,6 +1,8 @@
 package com.saerok.showing.api.domain.post.service.pagination;
 
 import com.saerok.showing.api.domain.comment.service.CommentCountProvider;
+import com.saerok.showing.api.domain.like.service.LikeReadService;
+import com.saerok.showing.api.domain.member.entity.Member;
 import com.saerok.showing.api.domain.post.dto.response.PostSummaryResponse;
 import com.saerok.showing.api.domain.post.entity.Post;
 import com.saerok.showing.api.domain.post.entity.PostSortType;
@@ -57,12 +59,18 @@ public class LatestPostPaginationStrategy implements PostPaginationStrategy {
         String cursorRaw,
         int limit,
         List<Long> teamIds,
-        CommentCountProvider commentCountProvider
+        CommentCountProvider commentCountProvider,
+        LikeReadService likeReadService,
+        Member currentMember
     ) {
         CreatedAtCursor cursor = (CreatedAtCursor) parseCursor(cursorRaw);
         List<Post> posts = paginate(postType, cursor, limit, teamIds);
         List<PostSummaryResponse> responses = posts.stream()
-            .map(post -> PostSummaryResponse.toDto(post, commentCountProvider.getCount(post.getId())))
+            .map(post -> {
+                boolean isLiked = likeReadService.isPostLiked(currentMember, post.getId());
+                int commentCount = commentCountProvider.getCount(post.getId());
+                return PostSummaryResponse.toDto(post, commentCount, isLiked);
+            })
             .toList();
         return CreatedAtCursorResult.of(responses, cursor, limit);
     }

--- a/src/main/java/com/saerok/showing/api/domain/post/service/pagination/PopularPostPaginationStrategy.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/service/pagination/PopularPostPaginationStrategy.java
@@ -1,6 +1,8 @@
 package com.saerok.showing.api.domain.post.service.pagination;
 
 import com.saerok.showing.api.domain.comment.service.CommentCountProvider;
+import com.saerok.showing.api.domain.like.service.LikeReadService;
+import com.saerok.showing.api.domain.member.entity.Member;
 import com.saerok.showing.api.domain.post.dto.response.PostSummaryResponse;
 import com.saerok.showing.api.domain.post.entity.Post;
 import com.saerok.showing.api.domain.post.entity.PostSortType;
@@ -65,12 +67,18 @@ public class PopularPostPaginationStrategy implements PostPaginationStrategy {
         String cursorRaw,
         int limit,
         List<Long> teamIds,
-        CommentCountProvider commentCountProvider
+        CommentCountProvider commentCountProvider,
+        LikeReadService likeReadService,
+        Member currentMember
     ) {
         PopularCursor cursor = (PopularCursor) parseCursor(cursorRaw);
         List<Post> posts = paginate(postType, cursor, limit, teamIds);
         List<PostSummaryResponse> responses = posts.stream()
-            .map(post -> PostSummaryResponse.toDto(post, commentCountProvider.getCount(post.getId())))
+            .map(post -> {
+                boolean isLiked = likeReadService.isPostLiked(currentMember, post.getId());
+                int commentCount = commentCountProvider.getCount(post.getId());
+                return PostSummaryResponse.toDto(post, commentCount, isLiked);
+            })
             .toList();
         return PopularCursorResult.of(responses, cursor, limit);
     }

--- a/src/main/java/com/saerok/showing/api/domain/post/service/pagination/PostPaginationStrategy.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/service/pagination/PostPaginationStrategy.java
@@ -1,6 +1,8 @@
 package com.saerok.showing.api.domain.post.service.pagination;
 
 import com.saerok.showing.api.domain.comment.service.CommentCountProvider;
+import com.saerok.showing.api.domain.like.service.LikeReadService;
+import com.saerok.showing.api.domain.member.entity.Member;
 import com.saerok.showing.api.domain.post.dto.response.PostSummaryResponse;
 import com.saerok.showing.api.domain.post.entity.Post;
 import com.saerok.showing.api.domain.post.entity.PostSortType;
@@ -21,6 +23,8 @@ public interface PostPaginationStrategy {
         String rawCursor,
         int limit,
         List<Long> teamIds,
-        CommentCountProvider commentCountProvider
+        CommentCountProvider commentCountProvider,
+        LikeReadService likeReadService,
+        Member currentMember
     );
 }

--- a/src/main/java/com/saerok/showing/api/domain/routePlace/controller/RoutePlaceController.java
+++ b/src/main/java/com/saerok/showing/api/domain/routePlace/controller/RoutePlaceController.java
@@ -32,7 +32,8 @@ public class RoutePlaceController {
         summary = "여행코스 내 장소 추가",
         description = """
             [모든 Role 가능] 여행코스에 장소를 추가합니다.<br>
-            장소는 방문 일자(dayNumber)와 해당 일자 내 방문 순서(orderInDay)를 함께 지정해야 합니다.
+            장소는 방문 일자(dayNumber)와 해당 일자 내 방문 순서(orderInDay)를 함께 지정해야 합니다.<br>
+            장소 추가는 TourAPI에서 제공하는 contentId, contentTypeId를 이용합니다.
             """
     )
     @PreAuthorize("hasRole('MEMBER')")

--- a/src/main/java/com/saerok/showing/api/domain/routePlace/dto/request/RoutePlaceCreateRequest.java
+++ b/src/main/java/com/saerok/showing/api/domain/routePlace/dto/request/RoutePlaceCreateRequest.java
@@ -34,4 +34,7 @@ public class RoutePlaceCreateRequest {
     @NotNull
     @Schema(description = "TourAPI 조회용 pk값 2", example = "1")
     private String contentTypeId;
+
+    @Schema(description = "TourAPI 이미지 썸네일 조회용 url", example = "")
+    private String imageUrl;
 }

--- a/src/main/java/com/saerok/showing/api/domain/routePlace/dto/request/RoutePlaceCreateRequest.java
+++ b/src/main/java/com/saerok/showing/api/domain/routePlace/dto/request/RoutePlaceCreateRequest.java
@@ -35,6 +35,9 @@ public class RoutePlaceCreateRequest {
     @Schema(description = "TourAPI 조회용 pk값 2", example = "1")
     private String contentTypeId;
 
-    @Schema(description = "TourAPI 이미지 썸네일 조회용 url", example = "")
+    @Schema(
+        description = "TourAPI 이미지 썸네일 조회용 url",
+        example = "https://tong.visitkorea.or.kr/cms/resource/52/3514552_image2_1.jpg"
+    )
     private String imageUrl;
 }

--- a/src/main/java/com/saerok/showing/api/domain/routePlace/dto/request/RoutePlaceUpdateRequest.java
+++ b/src/main/java/com/saerok/showing/api/domain/routePlace/dto/request/RoutePlaceUpdateRequest.java
@@ -37,16 +37,4 @@ public class RoutePlaceUpdateRequest {
 
     @Schema(description = "장소 이름", example = "엘리시안 강촌 리조트")
     private String placeName;
-
-    @Schema(description = "TourAPI 조회용 pk값 1", example = "1")
-    private String contentId;
-
-    @Schema(description = "TourAPI 조회용 pk값 2", example = "1")
-    private String contentTypeId;
-
-    @Schema(
-        description = "TourAPI 이미지 썸네일 조회용 url",
-        example = "https://tong.visitkorea.or.kr/cms/resource/52/3514552_image2_1.jpg"
-    )
-    private String imageUrl;
 }

--- a/src/main/java/com/saerok/showing/api/domain/routePlace/dto/request/RoutePlaceUpdateRequest.java
+++ b/src/main/java/com/saerok/showing/api/domain/routePlace/dto/request/RoutePlaceUpdateRequest.java
@@ -11,19 +11,27 @@ import lombok.Setter;
 @Setter
 public class RoutePlaceUpdateRequest {
 
-    @Min(1) @Max(30) @NotNull
+    @Min(1)
+    @Max(30)
+    @NotNull
     @Schema(description = "기존 일차(이동 전)", example = "1")
     private Integer oldDayNumber;
 
-    @Min(1) @Max(30) @NotNull
+    @Min(1)
+    @Max(30)
+    @NotNull
     @Schema(description = "기존 순서(이동 전)", example = "2")
     private Integer oldOrderInDay;
 
-    @Min(1) @Max(30) @NotNull
+    @Min(1)
+    @Max(30)
+    @NotNull
     @Schema(description = "새 일차(이동 후)", example = "1")
     private Integer dayNumber;
 
-    @Min(1) @Max(30) @NotNull
+    @Min(1)
+    @Max(30)
+    @NotNull
     @Schema(description = "새 순서(이동 후)", example = "1")
     private Integer orderInDay;
 
@@ -36,6 +44,9 @@ public class RoutePlaceUpdateRequest {
     @Schema(description = "TourAPI 조회용 pk값 2", example = "1")
     private String contentTypeId;
 
-    @Schema(description = "TourAPI 이미지 썸네일 조회용 url", example = "")
+    @Schema(
+        description = "TourAPI 이미지 썸네일 조회용 url",
+        example = "https://tong.visitkorea.or.kr/cms/resource/52/3514552_image2_1.jpg"
+    )
     private String imageUrl;
 }

--- a/src/main/java/com/saerok/showing/api/domain/routePlace/dto/request/RoutePlaceUpdateRequest.java
+++ b/src/main/java/com/saerok/showing/api/domain/routePlace/dto/request/RoutePlaceUpdateRequest.java
@@ -35,4 +35,7 @@ public class RoutePlaceUpdateRequest {
 
     @Schema(description = "TourAPI 조회용 pk값 2", example = "1")
     private String contentTypeId;
+
+    @Schema(description = "TourAPI 이미지 썸네일 조회용 url", example = "")
+    private String imageUrl;
 }

--- a/src/main/java/com/saerok/showing/api/domain/routePlace/dto/response/RoutePlaceBoxResponse.java
+++ b/src/main/java/com/saerok/showing/api/domain/routePlace/dto/response/RoutePlaceBoxResponse.java
@@ -19,7 +19,7 @@ public class RoutePlaceBoxResponse {
 
     private String contentTypeId;
 
-//    private String imageUrl;
+    private String imageUrl;
 
     public static RoutePlaceBoxResponse toDto(RoutePlace routePlace) {
         return RoutePlaceBoxResponse.builder()
@@ -28,7 +28,7 @@ public class RoutePlaceBoxResponse {
             .orderInDay(routePlace.getOrderInDay())
             .contentId(routePlace.getContentId())
             .contentTypeId(routePlace.getContentTypeId())
-//            .imageUrl(routePlace.getPlace().getPlaceImage())
+            .imageUrl(routePlace.getImageUrl())
             .build();
     }
 }

--- a/src/main/java/com/saerok/showing/api/domain/routePlace/entity/RoutePlace.java
+++ b/src/main/java/com/saerok/showing/api/domain/routePlace/entity/RoutePlace.java
@@ -55,6 +55,9 @@ public class RoutePlace extends BaseEntity {
     @Column(name = "content_type_id", nullable = false)
     private String contentTypeId;
 
+    @Column(name = "image_url", nullable = false)
+    private String imageUrl;
+
     public static RoutePlace toEntity(RoutePlaceCreateRequest request, Route route, String PlaceName) {
         return RoutePlace.builder()
             .route(route)
@@ -63,6 +66,7 @@ public class RoutePlace extends BaseEntity {
             .orderInDay(request.getOrderInDay())
             .contentId(request.getContentId())
             .contentTypeId(request.getContentTypeId())
+            .imageUrl(request.getImageUrl())
             .build();
     }
 

--- a/src/main/java/com/saerok/showing/api/domain/team/controller/TeamController.java
+++ b/src/main/java/com/saerok/showing/api/domain/team/controller/TeamController.java
@@ -34,7 +34,7 @@ public class TeamController {
             팀을 생성한 사람은 팀리더가 됩니다.<br>
             이미 팀이 존재하는 회원은 팀 생성을 할 수 없습니다.<br>
             팀명은 2~30글자 이며 중복이 불가능합니다.<br>
-            팀 인증코드는 영문자와 숫자를 조합한 4~30글자입니다.
+            팀 인증코드는 영문 대문자와 숫자를 조합한 6글자입니다.
             """
     )
     @PreAuthorize("hasRole('MEMBER')")
@@ -51,7 +51,7 @@ public class TeamController {
         description = """
             [모든 Role 가능] 팀에 가입합니다.<br>
             이미 팀이 존재하거나 요청한 팀에 가입된 경우는 가입되지 않습니다.
-            입장할 팁의 아이디와 비밀번호가 필요합니다.
+            입장할 팀의 이름과 비밀번호 6글자가 필요합니다.<br>
             """
     )
     @PreAuthorize("hasRole('MEMBER')")

--- a/src/main/java/com/saerok/showing/api/domain/team/dto/request/TeamCreateRequest.java
+++ b/src/main/java/com/saerok/showing/api/domain/team/dto/request/TeamCreateRequest.java
@@ -15,15 +15,15 @@ public class TeamCreateRequest {
     @Size(min = 2, max = 30)
     @Schema(
         description = "팀(그룹, 소속, 학교, 단체) 이름을 입력합니다, 팀 이름은 2 ~ 30글자 입니다.",
-        example = "금화초등학교"
+        example = "쇼윙"
     )
     private String name;
 
     @NotNull
-    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{4,30}$")
+    @Pattern(regexp = "^(?=.*[A-Z])(?=.*\\d)[A-Z\\d]{6}$")
     @Schema(
-        description = "팀 입장 비밀번호입니다. 영문과 숫자를 조합한 4~30자 이내의 문자열이어야 합니다.",
-        example = "team2025"
+        description = "팀 인증코드입니다. 영문 대문자와 숫자를 조합한 정확히 6자리 문자열이어야 합니다.",
+        example = "show25"
     )
     private String password;
 }

--- a/src/main/java/com/saerok/showing/api/domain/team/dto/request/TeamJoinRequest.java
+++ b/src/main/java/com/saerok/showing/api/domain/team/dto/request/TeamJoinRequest.java
@@ -3,7 +3,6 @@ package com.saerok.showing.api.domain.team.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -16,11 +15,10 @@ public class TeamJoinRequest {
     private String name;
 
     @NotNull
-    @Size(min = 4, max = 30)
-    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{4,30}$")
+    @Pattern(regexp = "^(?=.*[A-Z])(?=.*\\d)[A-Z\\d]{6}$")
     @Schema(
-        description = "팀 입장 시 사용하는 비밀번호입니다. 영문자와 숫자를 조합한 4~30자입니다.",
-        example = "team2025"
+        description = "팀 인증코드입니다. 영문 대문자와 숫자를 조합한 정확히 6자리 문자열이어야 합니다.",
+        example = "show25"
     )
     private String password;
 }


### PR DESCRIPTION
## ⭐️ Overview

> #66

좋아요 유무 확인 필드 추가하면서 일부 기획 변경 사항 반영했습니다.

## 🔧 Tasks

- 팀 인증코드 영문대문자 + 숫자를 포함한 6글자로 제한
- 게시글 조회 시 가시성 필드 추가
- 게시글/댓글 조회 시 로그인한 사용자의 좋아요 유무 필드 추가
- 여행코스 내 장소 추가/조회 시 이미지 url 필드 추가
- 소속된 팀 전체 조회 API 추가
- 수정된 기능들에 대해 API 명세 보강

## 📝 Additional Notes

- 수정 사항이 많아 Swagger 명세 및 노션 팀워크스페이스 확인 부탁드립니다.

## 📸 Screenshot

### 게시글 좋아요 유무 확인
<img width="650" alt="게시글 좋아요 유무 확인 필드 추가" src="https://github.com/user-attachments/assets/a0a66d65-d572-46fc-b63c-e0a3a4d48943" />

### 댓글 좋아요 유무 확인
<img width="650" alt="댓글 좋아요 유무 확인 필드 추가" src="https://github.com/user-attachments/assets/7e06c0b8-a73f-4081-ba40-950cc7eb0838" />

### 소속된 팀 전체 조회
<img width="500" alt="내가 소속된 팀 전체 조회 API" src="https://github.com/user-attachments/assets/0459268e-a197-4097-8384-4ce5ae195286" />
