### PR TITLE
refactor: 여행 코스 생성 시 테마 ID 지정 가능하도록 수정

### DIFF
--- a/src/main/java/com/saerok/showing/api/domain/route/dto/request/RouteCreateRequest.java
+++ b/src/main/java/com/saerok/showing/api/domain/route/dto/request/RouteCreateRequest.java
@@ -27,6 +27,9 @@ public class RouteCreateRequest {
     private LocalDate endDate;
 
     @Min(1) @Max(100) @NotNull
-    @Schema(description = "인원수, 1~100의 값을 가질 수 있습니다.", example = "15")
+    @Schema(description = "인원수, 1~100의 값을 가질 수 있습니다.", example = "8")
     private int peopleCount;
+
+    @Schema(description = "연결할 테마 ID, 없으면 null", example = "3")
+    private Long themeId;
 }

--- a/src/main/java/com/saerok/showing/api/domain/route/entity/Route.java
+++ b/src/main/java/com/saerok/showing/api/domain/route/entity/Route.java
@@ -49,17 +49,20 @@ public class Route extends BaseEntity {
     @Column(name = "title", nullable = false)
     private String title;
 
-    @Column(name = "start_date")
+    @Column(name = "start_date", nullable = false)
     private LocalDate startDate;
 
-    @Column(name = "end_date")
+    @Column(name = "end_date", nullable = false)
     private LocalDate endDate;
 
-    @Column(name = "people_count")
+    @Column(name = "people_count", nullable = false)
     private Integer peopleCount;
 
     @Column(name = "like_count", nullable = false)
     private int likeCount;
+
+    @Column(name = "theme_id")
+    private Long themeId;
 
     @OneToMany(mappedBy = "route", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<RoutePlace> routePlaces = new ArrayList<>();
@@ -76,6 +79,7 @@ public class Route extends BaseEntity {
             .endDate(request.getEndDate())
             .peopleCount(request.getPeopleCount())
             .likeCount(0)
+            .themeId(request.getThemeId())
             .build();
     }
 

--- a/src/main/java/com/saerok/showing/api/domain/team/controller/TeamController.java
+++ b/src/main/java/com/saerok/showing/api/domain/team/controller/TeamController.java
@@ -2,6 +2,7 @@ package com.saerok.showing.api.domain.team.controller;
 
 import com.saerok.showing.api.domain.team.dto.request.TeamCreateRequest;
 import com.saerok.showing.api.domain.team.dto.request.TeamJoinRequest;
+import com.saerok.showing.api.domain.team.dto.response.MyTeamResponse;
 import com.saerok.showing.api.domain.team.dto.response.TeamMemberResponse;
 import com.saerok.showing.api.domain.team.service.TeamService;
 import com.saerok.showing.api.global.response.ApiResponse;
@@ -94,6 +95,16 @@ public class TeamController {
     ) {
         List<TeamMemberResponse> members = teamService.getTeamMembers(teamId);
         return ApiResponse.success(members);
+    }
+
+    @Operation(
+        summary = "내가 소속된 팀 목록 조회",
+        description = "[모든 Role 가능] 현재 로그인한 사용자가 속한 모든 팀을 반환합니다."
+    )
+    @PreAuthorize("hasRole('MEMBER')")
+    @GetMapping("/me")
+    public ApiResponse<List<MyTeamResponse>> getMyTeams() {
+        return ApiResponse.success(teamService.getMyTeams());
     }
 
     @Operation(

--- a/src/main/java/com/saerok/showing/api/domain/team/dto/request/TeamCreateRequest.java
+++ b/src/main/java/com/saerok/showing/api/domain/team/dto/request/TeamCreateRequest.java
@@ -23,7 +23,7 @@ public class TeamCreateRequest {
     @Pattern(regexp = "^(?=.*[A-Z])(?=.*\\d)[A-Z\\d]{6}$")
     @Schema(
         description = "팀 인증코드입니다. 영문 대문자와 숫자를 조합한 정확히 6자리 문자열이어야 합니다.",
-        example = "show25"
+        example = "SHOW25"
     )
     private String password;
 }

--- a/src/main/java/com/saerok/showing/api/domain/team/dto/request/TeamJoinRequest.java
+++ b/src/main/java/com/saerok/showing/api/domain/team/dto/request/TeamJoinRequest.java
@@ -18,7 +18,7 @@ public class TeamJoinRequest {
     @Pattern(regexp = "^(?=.*[A-Z])(?=.*\\d)[A-Z\\d]{6}$")
     @Schema(
         description = "팀 인증코드입니다. 영문 대문자와 숫자를 조합한 정확히 6자리 문자열이어야 합니다.",
-        example = "show25"
+        example = "SHOW25"
     )
     private String password;
 }

--- a/src/main/java/com/saerok/showing/api/domain/team/dto/response/MyTeamResponse.java
+++ b/src/main/java/com/saerok/showing/api/domain/team/dto/response/MyTeamResponse.java
@@ -1,0 +1,25 @@
+package com.saerok.showing.api.domain.team.dto.response;
+
+import com.saerok.showing.api.domain.member.entity.Member;
+import com.saerok.showing.api.domain.team.entity.Team;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MyTeamResponse {
+
+    private Long teamId;
+
+    private String teamName;
+
+    private boolean leader;
+
+    public static MyTeamResponse toDto(Team team, Member member) {
+        return MyTeamResponse.builder()
+            .teamId(team.getId())
+            .teamName(team.getName())
+            .leader(team.isLeader(member))
+            .build();
+    }
+}

--- a/src/main/java/com/saerok/showing/api/domain/team/entity/Team.java
+++ b/src/main/java/com/saerok/showing/api/domain/team/entity/Team.java
@@ -9,7 +9,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -38,7 +38,7 @@ public class Team extends BaseEntity {
     @Column(name = "password", nullable = false)
     private String password;
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "leader_id", nullable = false)
     private Member leader;
 

--- a/src/main/java/com/saerok/showing/api/domain/team/repository/TeamRepository.java
+++ b/src/main/java/com/saerok/showing/api/domain/team/repository/TeamRepository.java
@@ -1,10 +1,8 @@
 package com.saerok.showing.api.domain.team.repository;
 
 import com.saerok.showing.api.domain.team.entity.Team;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -13,14 +11,4 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
     Optional<Team> findByName(String name);
 
     boolean existsByName(String name);
-
-    @Query("""
-            select distinct t
-            from Team t
-            join t.memberTeams mt
-            join fetch t.leader
-            where mt.member.id = :memberId
-            order by t.name asc
-        """)
-    List<Team> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/saerok/showing/api/domain/team/repository/TeamRepository.java
+++ b/src/main/java/com/saerok/showing/api/domain/team/repository/TeamRepository.java
@@ -1,8 +1,10 @@
 package com.saerok.showing.api.domain.team.repository;
 
 import com.saerok.showing.api.domain.team.entity.Team;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -11,4 +13,14 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
     Optional<Team> findByName(String name);
 
     boolean existsByName(String name);
+
+    @Query("""
+            select distinct t
+            from Team t
+            join t.memberTeams mt
+            join fetch t.leader
+            where mt.member.id = :memberId
+            order by t.name asc
+        """)
+    List<Team> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/saerok/showing/api/domain/team/service/TeamService.java
+++ b/src/main/java/com/saerok/showing/api/domain/team/service/TeamService.java
@@ -1,11 +1,11 @@
 package com.saerok.showing.api.domain.team.service;
 
 import com.saerok.showing.api.domain.member.entity.Member;
-import com.saerok.showing.api.domain.member.repository.MemberRepository;
 import com.saerok.showing.api.domain.memberTeam.entity.MemberTeam;
 import com.saerok.showing.api.domain.memberTeam.service.MemberTeamService;
 import com.saerok.showing.api.domain.team.dto.request.TeamCreateRequest;
 import com.saerok.showing.api.domain.team.dto.request.TeamJoinRequest;
+import com.saerok.showing.api.domain.team.dto.response.MyTeamResponse;
 import com.saerok.showing.api.domain.team.dto.response.TeamMemberResponse;
 import com.saerok.showing.api.domain.team.entity.Team;
 import com.saerok.showing.api.domain.team.repository.TeamRepository;
@@ -24,7 +24,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class TeamService {
 
     private final TeamRepository teamRepository;
-    private final MemberRepository memberRepository;
     private final MemberTeamService memberTeamService;
     private final BCryptPasswordEncoder passwordEncoder;
     private final LoginMemberProvider loginMemberProvider;
@@ -69,6 +68,15 @@ public class TeamService {
             .map(MemberTeam::getMember)
             .sorted(Comparator.comparing(Member::getCreatedAt))
             .map(member -> TeamMemberResponse.toDto(member, teamId))
+            .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<MyTeamResponse> getMyTeams() {
+        Member currentMember = loginMemberProvider.getCurrentLoginMember();
+        List<Team> teams = teamRepository.findAllByMemberId(currentMember.getId());
+        return teams.stream()
+            .map(t -> MyTeamResponse.toDto(t, currentMember))
             .toList();
     }
 

--- a/src/main/java/com/saerok/showing/api/domain/team/service/TeamService.java
+++ b/src/main/java/com/saerok/showing/api/domain/team/service/TeamService.java
@@ -74,9 +74,9 @@ public class TeamService {
     @Transactional(readOnly = true)
     public List<MyTeamResponse> getMyTeams() {
         Member currentMember = loginMemberProvider.getCurrentLoginMember();
-        List<Team> teams = teamRepository.findAllByMemberId(currentMember.getId());
-        return teams.stream()
-            .map(t -> MyTeamResponse.toDto(t, currentMember))
+        return memberTeamService.getTeamsByMemberId(currentMember.getId()).stream()
+            .map(MemberTeam::getTeam) // MemberTeam → Team
+            .map(team -> MyTeamResponse.toDto(team, currentMember))
             .toList();
     }
 

--- a/src/main/java/com/saerok/showing/api/domain/theme/dto/response/ThemeDetailResponse.java
+++ b/src/main/java/com/saerok/showing/api/domain/theme/dto/response/ThemeDetailResponse.java
@@ -23,6 +23,10 @@ public class ThemeDetailResponse {
 
     private String locationIntro;
 
+    private Double locationX;
+
+    private Double locationY;
+
     private List<String> highlightPoints;
 
     private List<DescriptionBlockResponse> descriptionBlocks;
@@ -50,6 +54,8 @@ public class ThemeDetailResponse {
             .title(theme.getTitle())
             .address(theme.getAddress())
             .locationIntro(theme.getLocationIntro())
+            .locationX(theme.getLocationX())
+            .locationY(theme.getLocationY())
             .highlightPoints(theme.getHighlightPoints())
             .descriptionBlocks(DescriptionBlockResponse.fromList(theme.getDescriptionBlocks()))
             .themeImage(theme.getThemeImage())


### PR DESCRIPTION
## ⭐️ Overview

> #68 

여행 코스 생성 시 테마 ID 지정 가능하도록 수정했습니다.
누락된 팀 전체 조회 관련 API 추가했습니다.
테마 상세 조회 시 필요한 위도, 경도 필드 추가했습니다.

## 🔧 Tasks

- 여행 코스 생성 시 테마 ID 지정 가능
- 팀 전체 조회 API 추가
- 테마 상세 조회 시 위도/경도 필드 추가

## 📸 Screenshot

### 여행 코스 생성
<img width="600" alt="여행코스 생성" src="https://github.com/user-attachments/assets/98312294-7d78-4eb2-ae31-d273edd1d5e8" />


### 테마 상세 조회
<img width="700" alt="테마 상세 조회" src="https://github.com/user-attachments/assets/ff2375c6-7331-4483-b980-83eef5de72bb" />

### 소속 팀 전체 조회
<img width="600" alt="소속팀 전체조회" src="https://github.com/user-attachments/assets/dd70ffb3-2f3b-4d9e-bd5b-280015d4f69f" />
