### PR TITLE
refactor: 게시글 공개 범위 및 팀 기반 게시글 조회 로직 리팩토링

### DIFF
--- a/src/main/java/com/saerok/showing/api/domain/memberTeam/service/MemberTeamService.java
+++ b/src/main/java/com/saerok/showing/api/domain/memberTeam/service/MemberTeamService.java
@@ -4,6 +4,7 @@ import com.saerok.showing.api.domain.member.entity.Member;
 import com.saerok.showing.api.domain.memberTeam.entity.MemberTeam;
 import com.saerok.showing.api.domain.memberTeam.repository.MemberTeamRepository;
 import com.saerok.showing.api.domain.team.entity.Team;
+import com.saerok.showing.api.domain.team.repository.TeamRepository;
 import com.saerok.showing.api.global.exception.ErrorCode;
 import com.saerok.showing.api.global.exception.ShowingException;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class MemberTeamService {
 
+    private final TeamRepository teamRepository;
     private final MemberTeamRepository memberTeamRepository;
 
     @Transactional
@@ -31,24 +33,25 @@ public class MemberTeamService {
         memberTeamRepository.delete(memberTeam);
     }
 
-    // 특정 팀의 모든 멤버 조회
     @Transactional(readOnly = true)
     public List<MemberTeam> getMembersByTeamId(Long teamId) {
         return memberTeamRepository.findWithMemberByTeamId(teamId);
     }
 
-    // 특정 멤버가 속한 모든 팀 조회
     @Transactional(readOnly = true)
     public List<MemberTeam> getTeamsByMemberId(Long memberId) {
         return memberTeamRepository.findWithTeamByMemberId(memberId);
     }
 
     @Transactional(readOnly = true)
-    public List<Long> getTeamIdsByMemberId(Long memberId) {
-        return memberTeamRepository.findWithTeamByMemberId(memberId)
-            .stream()
-            .map(mt -> mt.getTeam().getId())
-            .toList();
+    public Team findTeamById(Long teamId) {
+        return teamRepository.findById(teamId)
+            .orElseThrow(() -> ShowingException.from(ErrorCode.TEAM_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public boolean existsByMemberIdAndTeamId(Long memberId, Long teamId) {
+        return memberTeamRepository.existsByMemberIdAndTeamId(memberId, teamId);
     }
 
     private void validateNotAlreadyJoined(Member member, Team team) {

--- a/src/main/java/com/saerok/showing/api/domain/post/controller/PostController.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/controller/PostController.java
@@ -38,7 +38,8 @@ public class PostController {
             [모든 Role 가능] 게시글을 작성합니다.<br>
             요청 본문에는 제목, 내용, 게시글 타입, 게시글 이미지(리스트), 해시태그(리스트)가 포함됩니다.<br>
             게시글 이미지는 "/api/v1/file/post"를 이용하여 얻은 fileUrl값들을 입력해주세요.<br>
-            전체 공개는 VISIBLE_ALL, 팀만 공개는 TEAM_ONLY로 visibility를 지정해주세요.
+            전체 공개는 VISIBLE_ALL, 팀만 공개는 TEAM_ONLY로 visibility를 지정해주세요.<br>
+            팀이 여러 개인 경우 어느 팀에만 공개하는 게시글인지 해당 팀의 fk가 필요합니다.
             """
     )
     @PreAuthorize("hasRole('MEMBER')")
@@ -71,7 +72,7 @@ public class PostController {
             - `postType`을 생략하면 전체 게시글이 조회됩니다.<br>
             - 정렬 타입: 최신순(LATEST), 인기순(POPULAR)<br>
             - `sort`을 생략하면 최신순으로 정렬됩니다.<br>
-            
+            - 게시글 가시성: `teamId`가 없으면 전체 게시글, `teamId`가 있으면 해당 팀 게시글입니다.<br><br>
             📌 커서 기반 페이지네이션 안내<br>
             - `cursorRaw` : 마지막으로 조회된 게시글의 `createdAt` 값입니다. 이후의 데이터를 조회할 때 사용됩니다.<br>
             - `limit` : 한 번에 가져올 데이터 수입니다. 기본값은 4이며, 무한 스크롤에 사용됩니다.<br>
@@ -81,12 +82,13 @@ public class PostController {
     @PreAuthorize("hasRole('MEMBER')")
     @GetMapping("/list")
     public ApiResponse<CursorResult<PostSummaryResponse>> getPosts(
+        @RequestParam(name = "teamId", required = false) Long teamId,
         @RequestParam(name = "postType", required = false) PostType postType,
         @RequestParam(name = "sort", required = false, defaultValue = "LATEST") PostSortType sortType,
         @RequestParam(name = "cursorRaw", required = false) String cursorRaw,
         @RequestParam(name = "limit", defaultValue = "4") int limit
     ) {
-        CursorResult<PostSummaryResponse> result = postService.getPosts(postType, sortType, cursorRaw, limit);
+        CursorResult<PostSummaryResponse> result = postService.getPosts(teamId, postType, sortType, cursorRaw, limit);
         return ApiResponse.success(result);
     }
 

--- a/src/main/java/com/saerok/showing/api/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/dto/request/PostCreateRequest.java
@@ -41,4 +41,7 @@ public class PostCreateRequest {
     @NotNull
     @Schema(description = "해시태그 목록", example = "[\"#순천만습지\", \"#두루미\"]")
     private List<String> hashtags;
+
+    @Schema(description = "TEAM_ONLY인 경우 필수. 해당 팀 ID", example = "1")
+    private Long teamId;
 }

--- a/src/main/java/com/saerok/showing/api/domain/post/dto/request/PostUpdateRequest.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/dto/request/PostUpdateRequest.java
@@ -29,4 +29,7 @@ public class PostUpdateRequest {
     @NotNull
     @Schema(description = "해시태그 목록", example = "[\"#순천만습지\", \"#두루미\"]")
     private List<String> hashtags;
+
+    @Schema(description = "TEAM_ONLY인 경우 필수. 해당 팀 ID", example = "1")
+    private Long teamId;
 }

--- a/src/main/java/com/saerok/showing/api/domain/post/entity/Post.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/entity/Post.java
@@ -3,6 +3,7 @@ package com.saerok.showing.api.domain.post.entity;
 import com.saerok.showing.api.domain.member.entity.Member;
 import com.saerok.showing.api.domain.post.dto.request.PostCreateRequest;
 import com.saerok.showing.api.domain.post.dto.request.PostUpdateRequest;
+import com.saerok.showing.api.domain.team.entity.Team;
 import com.saerok.showing.api.global.entity.BaseEntity;
 import com.saerok.showing.api.global.exception.ErrorCode;
 import com.saerok.showing.api.global.exception.ShowingException;
@@ -74,8 +75,12 @@ public class Post extends BaseEntity {
     @Column(name = "like_count", nullable = false)
     private int likeCount;
 
-    public static Post toEntity(Member member, PostCreateRequest request, List<UploadedFile> files) {
-        return Post.builder()
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id")
+    private Team team;
+
+    public static Post toEntity(Member member, PostCreateRequest request, List<UploadedFile> files, Team team) {
+        Post post = Post.builder()
             .member(member)
             .title(request.getTitle())
             .visibility(request.getVisibility())
@@ -84,7 +89,10 @@ public class Post extends BaseEntity {
             .postImages(files)
             .hashtags(request.getHashtags())
             .likeCount(0)
+            .team(request.getVisibility() == PostVisibility.TEAM_ONLY ? team : null)
             .build();
+        post.validateVisibilityInvariant();
+        return post;
     }
 
     public void validateOwner(Member currentMember) {
@@ -93,11 +101,13 @@ public class Post extends BaseEntity {
         }
     }
 
-    public void update(PostUpdateRequest request) {
+    public void update(PostUpdateRequest request, Team teamIfTeamOnly) {
         this.title = request.getTitle();
         this.content = request.getContent();
         this.visibility = request.getVisibility();
         this.hashtags = request.getHashtags();
+        this.team = this.visibility == PostVisibility.TEAM_ONLY ? teamIfTeamOnly : null;
+        validateVisibilityInvariant();
     }
 
     public void increaseLikeCount() {
@@ -107,6 +117,15 @@ public class Post extends BaseEntity {
     public void decreaseLikeCount() {
         if (this.likeCount > 0) {
             this.likeCount--;
+        }
+    }
+
+    private void validateVisibilityInvariant() {
+        if (this.visibility == PostVisibility.TEAM_ONLY && this.team == null) {
+            throw ShowingException.from(ErrorCode.INVALID_POST_VISIBILITY);
+        }
+        if (this.visibility == PostVisibility.VISIBLE_ALL && this.team != null) {
+            throw ShowingException.from(ErrorCode.INVALID_POST_VISIBILITY);
         }
     }
 }

--- a/src/main/java/com/saerok/showing/api/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/repository/PostRepository.java
@@ -12,80 +12,116 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
 
+    // --- 전체 게시글 ---
+
     // 최신순 - 최초 페이지
     @Query("""
-        SELECT DISTINCT p
-        FROM Post p
-        LEFT JOIN MemberTeam mt ON p.member.id = mt.member.id
-        WHERE (:postType IS NULL OR p.postType = :postType)
-          AND (
-              p.visibility = 'VISIBLE_ALL'
-              OR (p.visibility = 'TEAM_ONLY' AND mt.team.id IN :teamIds)
-          )
+        SELECT p FROM Post p
+        WHERE p.visibility = 'VISIBLE_ALL'
+          AND (:postType IS NULL OR p.postType = :postType)
         ORDER BY p.createdAt DESC
         """)
-    List<Post> findVisiblePostsOrderByCreatedAtDesc(
-        @Param("postType") PostType postType,
-        @Param("teamIds") List<Long> teamIds
-    );
+    List<Post> findPublicPostsOrderByCreatedAtDesc(@Param("postType") PostType postType);
 
     // 최신순 - 커서 페이징
     @Query("""
-        SELECT DISTINCT p
-        FROM Post p
-        LEFT JOIN MemberTeam mt ON p.member.id = mt.member.id
-        WHERE (:postType IS NULL OR p.postType = :postType)
+        SELECT p FROM Post p
+        WHERE p.visibility = 'VISIBLE_ALL'
+          AND (:postType IS NULL OR p.postType = :postType)
           AND p.createdAt < :cursor
-          AND (
-              p.visibility = 'VISIBLE_ALL'
-              OR (p.visibility = 'TEAM_ONLY' AND mt.team.id IN :teamIds)
-          )
         ORDER BY p.createdAt DESC
         """)
-    List<Post> findVisiblePostsByCreatedAtBefore(
+    List<Post> findPublicPostsByCreatedAtBefore(
         @Param("postType") PostType postType,
-        @Param("cursor") LocalDateTime cursor,
-        @Param("teamIds") List<Long> teamIds
+        @Param("cursor") LocalDateTime cursor
     );
 
     // 인기순 - 최초 페이지
     @Query("""
-        SELECT DISTINCT p
-        FROM Post p
-        LEFT JOIN MemberTeam mt ON p.member.id = mt.member.id
-        WHERE (:postType IS NULL OR p.postType = :postType)
-          AND (
-              p.visibility = 'VISIBLE_ALL'
-              OR (p.visibility = 'TEAM_ONLY' AND mt.team.id IN :teamIds)
-          )
+        SELECT p FROM Post p
+        WHERE p.visibility = 'VISIBLE_ALL'
+          AND (:postType IS NULL OR p.postType = :postType)
         ORDER BY p.likeCount DESC, p.createdAt DESC
         """)
-    List<Post> findVisiblePostsOrderByLikeCountDesc(
-        @Param("postType") PostType postType,
-        @Param("teamIds") List<Long> teamIds
-    );
+    List<Post> findPublicPostsOrderByLikeCountDesc(@Param("postType") PostType postType);
 
     // 인기순 - 커서 페이징
     @Query("""
-        SELECT DISTINCT p
-        FROM Post p
-        LEFT JOIN MemberTeam mt ON p.member.id = mt.member.id
-        WHERE (:postType IS NULL OR p.postType = :postType)
+        SELECT p FROM Post p
+        WHERE p.visibility = 'VISIBLE_ALL'
+          AND (:postType IS NULL OR p.postType = :postType)
           AND (
               p.likeCount < :likeCount
               OR (p.likeCount = :likeCount AND p.createdAt < :createdAt)
           )
+        ORDER BY p.likeCount DESC, p.createdAt DESC
+        """)
+    List<Post> findPublicPostsByPopularCursor(
+        @Param("postType") PostType postType,
+        @Param("likeCount") int likeCount,
+        @Param("createdAt") LocalDateTime createdAt
+    );
+
+    // --- 팀별 게시글 ---
+
+    // 최신순 - 최초 페이지
+    @Query("""
+        SELECT p FROM Post p
+        WHERE p.visibility = 'TEAM_ONLY'
+          AND p.team.id = :teamId
+          AND (:postType IS NULL OR p.postType = :postType)
+        ORDER BY p.createdAt DESC
+        """)
+    List<Post> findTeamPostsOrderByCreatedAtDesc(
+        @Param("teamId") Long teamId,
+        @Param("postType") PostType postType
+    );
+
+    // 최신순 - 커서 페이징
+    @Query("""
+        SELECT p FROM Post p
+        WHERE p.visibility = 'TEAM_ONLY'
+          AND p.team.id = :teamId
+          AND (:postType IS NULL OR p.postType = :postType)
+          AND p.createdAt < :cursor
+        ORDER BY p.createdAt DESC
+        """)
+    List<Post> findTeamPostsByCreatedAtBefore(
+        @Param("teamId") Long teamId,
+        @Param("postType") PostType postType,
+        @Param("cursor") LocalDateTime cursor
+    );
+
+    // 인기순 - 최초 페이지
+    @Query("""
+        SELECT p FROM Post p
+        WHERE p.visibility = 'TEAM_ONLY'
+          AND p.team.id = :teamId
+          AND (:postType IS NULL OR p.postType = :postType)
+        ORDER BY p.likeCount DESC, p.createdAt DESC
+        """)
+    List<Post> findTeamPostsOrderByLikeCountDesc(
+        @Param("teamId") Long teamId,
+        @Param("postType") PostType postType
+    );
+
+    // 인기순 - 커서 페이징
+    @Query("""
+        SELECT p FROM Post p
+        WHERE p.visibility = 'TEAM_ONLY'
+          AND p.team.id = :teamId
+          AND (:postType IS NULL OR p.postType = :postType)
           AND (
-              p.visibility = 'VISIBLE_ALL'
-              OR (p.visibility = 'TEAM_ONLY' AND mt.team.id IN :teamIds)
+              p.likeCount < :likeCount
+              OR (p.likeCount = :likeCount AND p.createdAt < :createdAt)
           )
         ORDER BY p.likeCount DESC, p.createdAt DESC
         """)
-    List<Post> findVisiblePostsByPopularCursor(
+    List<Post> findTeamPostsByPopularCursor(
+        @Param("teamId") Long teamId,
         @Param("postType") PostType postType,
         @Param("likeCount") int likeCount,
-        @Param("createdAt") LocalDateTime createdAt,
-        @Param("teamIds") List<Long> teamIds
+        @Param("createdAt") LocalDateTime createdAt
     );
 
     int countByMemberId(Long memberId);

--- a/src/main/java/com/saerok/showing/api/domain/post/service/PostService.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/service/PostService.java
@@ -11,18 +11,18 @@ import com.saerok.showing.api.domain.post.dto.response.PostSummaryResponse;
 import com.saerok.showing.api.domain.post.entity.Post;
 import com.saerok.showing.api.domain.post.entity.PostSortType;
 import com.saerok.showing.api.domain.post.entity.PostType;
+import com.saerok.showing.api.domain.post.entity.PostVisibility;
 import com.saerok.showing.api.domain.post.repository.PostRepository;
 import com.saerok.showing.api.domain.post.service.pagination.PostPaginationStrategy;
 import com.saerok.showing.api.domain.post.service.pagination.PostPaginationStrategyFactory;
+import com.saerok.showing.api.domain.team.entity.Team;
 import com.saerok.showing.api.global.auth.util.LoginMemberProvider;
 import com.saerok.showing.api.global.exception.ErrorCode;
 import com.saerok.showing.api.global.exception.ShowingException;
 import com.saerok.showing.api.global.file.entity.UploadedFile;
 import com.saerok.showing.api.global.file.service.FileService;
 import com.saerok.showing.api.global.pagination.cursorResult.CursorResult;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,34 +43,45 @@ public class PostService {
     public Long save(PostCreateRequest request) {
         Member member = loginMemberProvider.getCurrentLoginMember();
         List<UploadedFile> files = fileService.getUploadedFilesByUrls(request.getImageUrls());
-        Post post = Post.toEntity(member, request, files);
+        Team team = resolveTeamIfNeeded(request, member);
+        Post post = Post.toEntity(member, request, files, team);
         postRepository.save(post);
         return post.getId();
     }
 
     @Transactional(readOnly = true)
     public PostDetailResponse getPostDetails(Long postId) {
-        Member currentMember = loginMemberProvider.getCurrentLoginMember();
-        List<Long> teamIds = memberTeamService.getTeamIdsByMemberId(currentMember.getId());
+        Member member = loginMemberProvider.getCurrentLoginMember();
         Post post = findById(postId);
-        validatePostVisibility(post, teamIds);
+        validateReadable(post, member);
         int commentCount = commentCountProvider.getCount(postId);
-        boolean isLiked = likeReadService.isPostLiked(currentMember, postId);
+        boolean isLiked = likeReadService.isPostLiked(member, postId);
         return PostDetailResponse.toDto(post, commentCount, isLiked);
     }
 
     @Transactional(readOnly = true)
     public CursorResult<PostSummaryResponse> getPosts(
+        Long teamId,
         PostType postType,
         PostSortType sortType,
         String cursorRaw,
         int limit
     ) {
-        Member currentMember = loginMemberProvider.getCurrentLoginMember();
-        List<Long> teamIds = memberTeamService.getTeamIdsByMemberId(currentMember.getId());
+        Member member = loginMemberProvider.getCurrentLoginMember();
         PostPaginationStrategy strategy = postPaginationStrategyFactory.getStrategy(sortType);
-        return strategy.getCursorResult(postType, cursorRaw, limit, teamIds, commentCountProvider, likeReadService,
-            currentMember);
+        if (teamId == null) {
+            // 전체 피드 (VISIBLE_ALL만 조회)
+            return strategy.getCursorResult(null, postType, cursorRaw, limit, commentCountProvider, likeReadService,
+                member
+            );
+        }
+        // 팀 피드 (TEAM_ONLY + 해당 팀만 조회)
+        if (!isMemberOfTeam(member.getId(), teamId)) {
+            throw ShowingException.from(ErrorCode.NO_TEAM_MEMBER_PERMISSION);
+        }
+        return strategy.getCursorResult(
+            teamId, postType, cursorRaw, limit, commentCountProvider, likeReadService, member
+        );
     }
 
     @Transactional
@@ -78,7 +89,8 @@ public class PostService {
         Member member = loginMemberProvider.getCurrentLoginMember();
         Post post = findById(postId);
         post.validateOwner(member);
-        post.update(request);
+        Team team = resolveTeamIfNeeded(request, member);
+        post.update(request, team);
         return post.getId();
     }
 
@@ -91,16 +103,6 @@ public class PostService {
         return postId;
     }
 
-    private void validatePostVisibility(Post post, List<Long> viewerTeamIds) {
-        if (post.getVisibility().isTeamOnly()) {
-            Set<Long> authorTeamIds = new HashSet<>(memberTeamService.getTeamIdsByMemberId(post.getMember().getId()));
-            viewerTeamIds.stream()
-                .filter(authorTeamIds::contains)
-                .findAny()
-                .orElseThrow(() -> ShowingException.from(ErrorCode.FORBIDDEN));
-        }
-    }
-
     public int getPostCount() {
         Long memberId = loginMemberProvider.getCurrentLoginMemberId();
         return postRepository.countByMemberId(memberId);
@@ -109,5 +111,42 @@ public class PostService {
     public Post findById(Long postId) {
         return postRepository.findById(postId)
             .orElseThrow(() -> ShowingException.from(ErrorCode.POST_NOT_FOUND));
+    }
+
+    private Team resolveTeamIfNeeded(PostCreateRequest request, Member member) {
+        return resolveTeamIfNeeded(request.getVisibility(), request.getTeamId(), member);
+    }
+
+    private Team resolveTeamIfNeeded(PostUpdateRequest request, Member member) {
+        return resolveTeamIfNeeded(request.getVisibility(), request.getTeamId(), member);
+    }
+
+    // TEAM_ONLY일 경우 teamId 유효성 검증 및 팀 멤버 여부 확인
+    private Team resolveTeamIfNeeded(PostVisibility visibility, Long teamId, Member member) {
+        if (visibility.isVisibleAll()) {
+            return null;
+        }
+        if (teamId == null) {
+            throw ShowingException.from(ErrorCode.INVALID_POST_VISIBILITY);
+        }
+        Team team = memberTeamService.findTeamById(teamId);
+        if (!isMemberOfTeam(member.getId(), team.getId())) {
+            throw ShowingException.from(ErrorCode.NO_TEAM_MEMBER_PERMISSION);
+        }
+        return team;
+    }
+
+    // 가시성 검증
+    private void validateReadable(Post post, Member member) {
+        if (post.getVisibility().isVisibleAll()) {
+            return;
+        }
+        if (!isMemberOfTeam(member.getId(), post.getTeam().getId())) {
+            throw ShowingException.from(ErrorCode.NO_TEAM_MEMBER_PERMISSION);
+        }
+    }
+
+    private boolean isMemberOfTeam(Long memberId, Long teamId) {
+        return memberTeamService.existsByMemberIdAndTeamId(memberId, teamId);
     }
 }

--- a/src/main/java/com/saerok/showing/api/domain/post/service/pagination/LatestPostPaginationStrategy.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/service/pagination/LatestPostPaginationStrategy.java
@@ -42,29 +42,37 @@ public class LatestPostPaginationStrategy implements PostPaginationStrategy {
     }
 
     @Override
-    public List<Post> paginate(PostType postType, Object cursor, int limit, List<Long> teamIds) {
+    public List<Post> paginate(Long teamId, PostType postType, Object cursor, int limit) {
         LocalDateTime cursorTime = (cursor instanceof CreatedAtCursor c) ? c.createdAt() : null;
-        return (
-            cursorTime == null
-                ? postRepository.findVisiblePostsOrderByCreatedAtDesc(postType, teamIds)
-                : postRepository.findVisiblePostsByCreatedAtBefore(postType, cursorTime, teamIds)
-        ).stream()
+        List<Post> posts;
+        if (teamId == null) {
+            // 전체 피드 (VISIBLE_ALL)
+            posts = (cursorTime == null
+                ? postRepository.findPublicPostsOrderByCreatedAtDesc(postType)
+                : postRepository.findPublicPostsByCreatedAtBefore(postType, cursorTime));
+        } else {
+            // 팀 피드 (TEAM_ONLY)
+            posts = (cursorTime == null
+                ? postRepository.findTeamPostsOrderByCreatedAtDesc(teamId, postType)
+                : postRepository.findTeamPostsByCreatedAtBefore(teamId, postType, cursorTime));
+        }
+        return posts.stream()
             .limit(limit + 1)
             .toList();
     }
 
     @Override
     public CursorResult<PostSummaryResponse> getCursorResult(
+        Long teamId,
         PostType postType,
         String cursorRaw,
         int limit,
-        List<Long> teamIds,
         CommentCountProvider commentCountProvider,
         LikeReadService likeReadService,
         Member currentMember
     ) {
         CreatedAtCursor cursor = (CreatedAtCursor) parseCursor(cursorRaw);
-        List<Post> posts = paginate(postType, cursor, limit, teamIds);
+        List<Post> posts = paginate(teamId, postType, cursor, limit);
         List<PostSummaryResponse> responses = posts.stream()
             .map(post -> {
                 boolean isLiked = likeReadService.isPostLiked(currentMember, post.getId());

--- a/src/main/java/com/saerok/showing/api/domain/post/service/pagination/PopularPostPaginationStrategy.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/service/pagination/PopularPostPaginationStrategy.java
@@ -45,34 +45,37 @@ public class PopularPostPaginationStrategy implements PostPaginationStrategy {
     }
 
     @Override
-    public List<Post> paginate(PostType postType, Object cursor, int limit, List<Long> teamIds) {
-        if (cursor == null) {
-            return postRepository.findVisiblePostsOrderByLikeCountDesc(postType, teamIds)
-                .stream()
-                .limit(limit + 1)
-                .toList();
+    public List<Post> paginate(Long teamId, PostType postType, Object cursor, int limit) {
+        PopularCursor c = (cursor instanceof PopularCursor pc) ? pc : null;
+        List<Post> posts;
+        if (teamId == null) {
+            // 전체 피드 (VISIBLE_ALL)
+            posts = (c == null
+                ? postRepository.findPublicPostsOrderByLikeCountDesc(postType)
+                : postRepository.findPublicPostsByPopularCursor(postType, c.likeCount(), c.createdAt()));
+        } else {
+            // 팀 피드 (TEAM_ONLY)
+            posts = (c == null
+                ? postRepository.findTeamPostsOrderByLikeCountDesc(teamId, postType)
+                : postRepository.findTeamPostsByPopularCursor(teamId, postType, c.likeCount(), c.createdAt()));
         }
-        if (cursor instanceof PopularCursor c) {
-            return postRepository.findVisiblePostsByPopularCursor(postType, c.likeCount(), c.createdAt(), teamIds)
-                .stream()
-                .limit(limit + 1)
-                .toList();
-        }
-        throw ShowingException.from(ErrorCode.INVALID_CURSOR_FORMAT);
+        return posts.stream()
+            .limit(limit + 1)
+            .toList();
     }
 
     @Override
     public CursorResult<PostSummaryResponse> getCursorResult(
+        Long teamId,
         PostType postType,
         String cursorRaw,
         int limit,
-        List<Long> teamIds,
         CommentCountProvider commentCountProvider,
         LikeReadService likeReadService,
         Member currentMember
     ) {
         PopularCursor cursor = (PopularCursor) parseCursor(cursorRaw);
-        List<Post> posts = paginate(postType, cursor, limit, teamIds);
+        List<Post> posts = paginate(teamId, postType, cursor, limit);
         List<PostSummaryResponse> responses = posts.stream()
             .map(post -> {
                 boolean isLiked = likeReadService.isPostLiked(currentMember, post.getId());

--- a/src/main/java/com/saerok/showing/api/domain/post/service/pagination/PostPaginationStrategy.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/service/pagination/PostPaginationStrategy.java
@@ -16,13 +16,13 @@ public interface PostPaginationStrategy {
 
     Object parseCursor(String rawCursor);
 
-    List<Post> paginate(PostType postType, Object cursor, int limit, List<Long> teamIds);
+    List<Post> paginate(Long teamId, PostType postType, Object cursor, int limit);
 
     CursorResult<PostSummaryResponse> getCursorResult(
+        Long teamId,
         PostType postType,
         String rawCursor,
         int limit,
-        List<Long> teamIds,
         CommentCountProvider commentCountProvider,
         LikeReadService likeReadService,
         Member currentMember

--- a/src/main/java/com/saerok/showing/api/domain/team/service/TeamService.java
+++ b/src/main/java/com/saerok/showing/api/domain/team/service/TeamService.java
@@ -92,7 +92,7 @@ public class TeamService {
         return teamId;
     }
 
-    private Team findById(Long teamId) {
+    public Team findById(Long teamId) {
         return teamRepository.findById(teamId)
             .orElseThrow(() -> ShowingException.from(ErrorCode.TEAM_NOT_FOUND));
     }

--- a/src/main/java/com/saerok/showing/api/global/exception/ErrorCode.java
+++ b/src/main/java/com/saerok/showing/api/global/exception/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     INVALID_CURSOR_FORMAT(HttpStatus.BAD_REQUEST, "커서 형식이 잘못되었습니다."),
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "유효하지 않은 입력 값입니다."),
     INVALID_ROUTE_TITLE(HttpStatus.BAD_REQUEST, "여행코스 제목이 비어 있거나 올바르지 않습니다."),
+    INVALID_POST_VISIBILITY(HttpStatus.BAD_REQUEST, "게시글 공개 범위와 팀 정보가 올바르지 않습니다."),
 
     // 401: UNAUTHORIZED (인증 실패)
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
@@ -45,6 +46,7 @@ public enum ErrorCode {
     NO_TEAM_LEADER_PERMISSION(HttpStatus.FORBIDDEN, "요청한 사항은 팀 리더만 가능합니다."),
     ALREADY_JOINED_TEAM(HttpStatus.FORBIDDEN, "이미 팀에 가입되어 있습니다."),
     NOT_MEMBER_OF_TEAM(HttpStatus.FORBIDDEN, "요청한 팀에 소속되어 있지 않습니다."),
+    NO_TEAM_MEMBER_PERMISSION(HttpStatus.FORBIDDEN, "팀 멤버만 접근할 수 있습니다."),
 
     // 404: NOT FOUND (리소스를 찾을 수 없음)
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다."),


### PR DESCRIPTION
## ⭐️ Overview

> #71

게시글 공개 범위(`VISIBLE_ALL`, `TEAM_ONLY`)에 따른 조회 및 접근 제어 로직을 개선했습니다.

## 🔧 Tasks

- PostRepository 및 PaginationStrategy 리팩토링
- 기존 로직과의 호환성 검증(인기순/최신순, 페이지네이션, 전체조회/팀별조회)

## 📝 Additional Notes

- `teamId` 미입력 시 전체 피드 조회이며, `VISIBLE_ALL` 게시글만 조회됩니다.
- `teamId` 입력 시 팀 피드 조회이며, `TEAM_ONLY` + 해당 팀 게시글만 조회됩니다.
- url 조건 확인해주세요.

## 📸 Screenshot

### 전체 게시글 조회(`teamId` 미입력)
<img width="700" alt="전체 게시글 조회" src="https://github.com/user-attachments/assets/918e7fca-8453-4640-8310-ff820a644f55" />

### 팀별 게시글 조회(`teamId` 입력)
<img width="700" alt="팀별 게시글 조회" src="https://github.com/user-attachments/assets/01cb3bf0-5118-47c6-b6c9-3ca608373a33" />
