### PR TITLE
refactor: 여행루트 내 장소 추가/조회 시 필드 확장

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,7 +102,7 @@ jobs:
       # 최신 이미지를 컨테이너화하여 실행
       - name: docker run new container
         run: |
-          sudo docker run --name spring \
+          sudo docker run -d --name spring \
             --network app-net \
             --restart unless-stopped \
             -p ${{ secrets.SERVER_PORT }}:${{ secrets.SERVER_PORT }} \

--- a/src/main/java/com/saerok/showing/api/domain/post/controller/PostController.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/controller/PostController.java
@@ -36,9 +36,10 @@ public class PostController {
         summary = "게시글 등록",
         description = """
             [모든 Role 가능] 게시글을 작성합니다.<br>
-            요청 본문에는 제목, 내용, 게시글 타입, 게시글 이미지(리스트), 해시태그(리스트)가 포함됩니다.<br>
+            요청 본문에는 제목, 내용, 게시글 타입, 게시글 이미지(리스트), 해시태그(리스트), 팀id가 포함됩니다.<br>
             게시글 이미지는 "/api/v1/file/post"를 이용하여 얻은 fileUrl값들을 입력해주세요.<br>
             전체 공개는 VISIBLE_ALL, 팀만 공개는 TEAM_ONLY로 visibility를 지정해주세요.<br>
+            전체 공개 시에는 팀id 필드를 null로 주시면 됩니다.<br>
             팀이 여러 개인 경우 어느 팀에만 공개하는 게시글인지 해당 팀의 fk가 필요합니다.
             """
     )
@@ -67,12 +68,12 @@ public class PostController {
     @Operation(
         summary = "게시글 전체 조회",
         description = """
-            [모든 Role 가능] 게시글 타입에 따른 카테고리별 게시글을 조회합니다.<br>
-            - 게시글 타입: 일반(NORMAL), 여행계획(ROUTE)<br>
+            [모든 Role 가능]카테고리별 게시글을 조회합니다.<br>
+            - 게시글 가시성: `teamId`가 없으면 전체 게시글, `teamId`가 있으면 해당 팀 게시글입니다.<br>
+            - 게시글 타입: 일반(NORMAL), 투표(POLL)<br>
             - `postType`을 생략하면 전체 게시글이 조회됩니다.<br>
             - 정렬 타입: 최신순(LATEST), 인기순(POPULAR)<br>
-            - `sort`을 생략하면 최신순으로 정렬됩니다.<br>
-            - 게시글 가시성: `teamId`가 없으면 전체 게시글, `teamId`가 있으면 해당 팀 게시글입니다.<br><br>
+            - `sort`을 생략하면 최신순으로 정렬됩니다.<br><br>
             📌 커서 기반 페이지네이션 안내<br>
             - `cursorRaw` : 마지막으로 조회된 게시글의 `createdAt` 값입니다. 이후의 데이터를 조회할 때 사용됩니다.<br>
             - `limit` : 한 번에 가져올 데이터 수입니다. 기본값은 4이며, 무한 스크롤에 사용됩니다.<br>

--- a/src/main/java/com/saerok/showing/api/domain/routePlace/dto/request/RoutePlaceCreateRequest.java
+++ b/src/main/java/com/saerok/showing/api/domain/routePlace/dto/request/RoutePlaceCreateRequest.java
@@ -35,9 +35,22 @@ public class RoutePlaceCreateRequest {
     @Schema(description = "TourAPI 조회용 pk값 2", example = "1")
     private String contentTypeId;
 
+    @NotNull
     @Schema(
         description = "TourAPI 이미지 썸네일 조회용 url",
         example = "https://tong.visitkorea.or.kr/cms/resource/52/3514552_image2_1.jpg"
     )
     private String imageUrl;
+
+    @NotNull
+    @Schema(description = "TourAPI에서 받아온 위도", example = "37.8228")
+    private Double latitude;
+
+    @NotNull
+    @Schema(description = "TourAPI에서 받아온 경도", example = "127.6375")
+    private Double longitude;
+
+    @NotNull
+    @Schema(description = "TourAPI에서 받아온 주소", example = "강원 춘천시 남산면 북한강변길 688")
+    private String address;
 }

--- a/src/main/java/com/saerok/showing/api/domain/routePlace/dto/response/RoutePlaceBoxResponse.java
+++ b/src/main/java/com/saerok/showing/api/domain/routePlace/dto/response/RoutePlaceBoxResponse.java
@@ -21,6 +21,12 @@ public class RoutePlaceBoxResponse {
 
     private String imageUrl;
 
+    private Double latitude;
+
+    private Double longitude;
+
+    private String address;
+
     public static RoutePlaceBoxResponse toDto(RoutePlace routePlace) {
         return RoutePlaceBoxResponse.builder()
             .title(routePlace.getPlaceName())
@@ -29,6 +35,9 @@ public class RoutePlaceBoxResponse {
             .contentId(routePlace.getContentId())
             .contentTypeId(routePlace.getContentTypeId())
             .imageUrl(routePlace.getImageUrl())
+            .latitude(routePlace.getLatitude())
+            .longitude(routePlace.getLongitude())
+            .address(routePlace.getAddress())
             .build();
     }
 }

--- a/src/main/java/com/saerok/showing/api/domain/routePlace/entity/RoutePlace.java
+++ b/src/main/java/com/saerok/showing/api/domain/routePlace/entity/RoutePlace.java
@@ -58,6 +58,15 @@ public class RoutePlace extends BaseEntity {
     @Column(name = "image_url", nullable = false)
     private String imageUrl;
 
+    @Column(name = "latitude", nullable = false)
+    private Double latitude;
+
+    @Column(name = "longitude", nullable = false)
+    private Double longitude;
+
+    @Column(name = "address", nullable = false)
+    private String address;
+
     public static RoutePlace toEntity(RoutePlaceCreateRequest request, Route route, String PlaceName) {
         return RoutePlace.builder()
             .route(route)
@@ -67,6 +76,7 @@ public class RoutePlace extends BaseEntity {
             .contentId(request.getContentId())
             .contentTypeId(request.getContentTypeId())
             .imageUrl(request.getImageUrl())
+
             .build();
     }
 

--- a/src/main/java/com/saerok/showing/api/domain/routePlace/entity/RoutePlace.java
+++ b/src/main/java/com/saerok/showing/api/domain/routePlace/entity/RoutePlace.java
@@ -76,7 +76,9 @@ public class RoutePlace extends BaseEntity {
             .contentId(request.getContentId())
             .contentTypeId(request.getContentTypeId())
             .imageUrl(request.getImageUrl())
-
+            .longitude(request.getLatitude())
+            .latitude(request.getLatitude())
+            .address(request.getAddress())
             .build();
     }
 


### PR DESCRIPTION
## ⭐️ Overview

> #73 

여행 루트 내 장소 추가/조회 시 위도, 경도, 주소 필드를 함께 저장할 수 있도록 스펙을 확장했습니다.

## 🔧 Tasks

- 장소 추가/조회 시 `latitude`, `longitude`, `address` 필드 확장
- 기존 로직과의 호환성 검토 및 안정성 확인

## 📸 Screenshot

### 여행루트 내 장소 추가
<img width="700" alt="여행루트 내 장소 추가" src="https://github.com/user-attachments/assets/3bbefdf7-862d-4751-93db-72f0e4a7b5b3" />
