### PR TITLE
refactor: 팀 소속 멤버만 투표 조회 및 참여 가능하도록 접근 제한 로직 리팩토링

### DIFF
--- a/src/main/java/com/saerok/showing/api/domain/poll/controller/PollController.java
+++ b/src/main/java/com/saerok/showing/api/domain/poll/controller/PollController.java
@@ -31,7 +31,8 @@ public class PollController {
     @Operation(
         summary = "투표 등록",
         description = """
-            [모든 Role 가능] 투표를 등록합니다.
+            [모든 Role 가능] 새 투표를 등록합니다.<br>
+            투표 등록 시, 반드시 teamId를 입력해야하며, 해당 투표 조회와 후보지 등록은 팀원만 가능합니다.
             """
     )
     @PreAuthorize("hasRole('MEMBER')")
@@ -60,8 +61,8 @@ public class PollController {
         summary = "투표 후보 등록",
         description = """
             [모든 Role 가능] 투표에 여행 경로(Route)를 하나 등록합니다.<br>
-            자신이 생성한 여행 경로 중 하나를 투표 후보로 올릴 수 있으며,<br>
-            동일한 경로는 중복 등록할 수 없습니다.
+            현재 로그인한 사용자가 해당 팀의 멤버인 경우만 등록할 수 있습니다. <br>
+            자신이 생성한 여행 경로 중 하나를 투표 후보로 올릴 수 있으며, 동일한 경로는 중복 등록할 수 없습니다.
             """
     )
     @PreAuthorize("hasRole('MEMBER')")
@@ -76,7 +77,11 @@ public class PollController {
 
     @Operation(
         summary = "투표 수정",
-        description = "[모든 Role 가능] 투표 ID를 기준으로 내용 및 투표 상태를 수정합니다."
+        description = """
+            [모든 Role 가능] 투표 ID를 기준으로 내용 및 투표 상태를 수정합니다.<br>
+            수정 권한은 해당 투표 생성자에게만 부여됩니다.<br>
+            팀 미소속자 또는 작성자가 아닐 경우 오류를 반환합니다.
+            """
     )
     @PreAuthorize("hasRole('MEMBER')")
     @PatchMapping("/{pollId}")
@@ -90,7 +95,10 @@ public class PollController {
 
     @Operation(
         summary = "투표 삭제",
-        description = "[모든 Role 가능] 투표 ID를 기준으로 투표를 삭제합니다."
+        description = """
+            [모든 Role 가능] 투표 ID를 기준으로 투표를 삭제합니다.<br>
+            삭제 권한은 해당 투표 생성자에게만 부여됩니다.
+            """
     )
     @PreAuthorize("hasRole('MEMBER')")
     @DeleteMapping("/{pollId}")
@@ -100,5 +108,4 @@ public class PollController {
         Long id = pollService.delete(pollId);
         return ApiResponse.success(id);
     }
-
 }

--- a/src/main/java/com/saerok/showing/api/domain/poll/dto/request/PollCreateRequest.java
+++ b/src/main/java/com/saerok/showing/api/domain/poll/dto/request/PollCreateRequest.java
@@ -28,4 +28,8 @@ public class PollCreateRequest {
     @NotNull
     @Schema(description = "투표 종료일 (YYYY-MM-DD)", example = "2025-08-17")
     private LocalDate endDate;
+
+    @NotNull
+    @Schema(description = "투표를 올릴 팀 id", example = "1")
+    private Long teamId;
 }

--- a/src/main/java/com/saerok/showing/api/domain/poll/dto/request/PollCreateRequest.java
+++ b/src/main/java/com/saerok/showing/api/domain/poll/dto/request/PollCreateRequest.java
@@ -14,7 +14,7 @@ public class PollCreateRequest {
 
     @NotNull
     @Size(max = 50, message = "투표 제목은 최대 50자까지 입력할 수 있습니다.")
-    @Schema(description = "투표 제목", example = "8/16일 현장체험학습으로 어디를 가면 좋을까?")
+    @Schema(description = "투표 제목", example = "9/16일 현장체험학습으로 어디를 가면 좋을까?")
     private String title;
 
     @NotNull
@@ -22,11 +22,11 @@ public class PollCreateRequest {
     private PollStatus pollStatus;
 
     @NotNull
-    @Schema(description = "투표 시작일 (YYYY-MM-DD)", example = "2025-08-16")
+    @Schema(description = "투표 시작일 (YYYY-MM-DD)", example = "2025-09-16")
     private LocalDate startDate;
 
     @NotNull
-    @Schema(description = "투표 종료일 (YYYY-MM-DD)", example = "2025-08-17")
+    @Schema(description = "투표 종료일 (YYYY-MM-DD)", example = "2025-09-18")
     private LocalDate endDate;
 
     @NotNull

--- a/src/main/java/com/saerok/showing/api/domain/poll/dto/request/PollUpdateRequest.java
+++ b/src/main/java/com/saerok/showing/api/domain/poll/dto/request/PollUpdateRequest.java
@@ -14,7 +14,7 @@ public class PollUpdateRequest {
 
     @NotNull
     @Size(max = 50, message = "투표 제목은 최대 50자까지 입력할 수 있습니다.")
-    @Schema(description = "투표 제목", example = "8/16일 현장체험학습으로 어디를 가면 좋을까요?")
+    @Schema(description = "투표 제목", example = "9/16일 현장체험학습으로 어디를 가면 좋을까요?")
     private String title;
 
     @NotNull
@@ -22,10 +22,10 @@ public class PollUpdateRequest {
     private PollStatus pollStatus;
 
     @NotNull
-    @Schema(description = "투표 시작일 (YYYY-MM-DD)", example = "2025-08-16")
+    @Schema(description = "투표 시작일 (YYYY-MM-DD)", example = "2025-09-16")
     private LocalDate startDate;
 
     @NotNull
-    @Schema(description = "투표 종료일 (YYYY-MM-DD)", example = "2025-08-18")
+    @Schema(description = "투표 종료일 (YYYY-MM-DD)", example = "2025-09-19")
     private LocalDate endDate;
 }

--- a/src/main/java/com/saerok/showing/api/domain/poll/dto/response/PollDetailResponse.java
+++ b/src/main/java/com/saerok/showing/api/domain/poll/dto/response/PollDetailResponse.java
@@ -31,6 +31,8 @@ public class PollDetailResponse {
 
     private List<RouteSummaryResponse> routes;
 
+    private Long teamId;
+
     public static PollDetailResponse toDto(
         Poll poll,
         Member member,
@@ -47,6 +49,7 @@ public class PollDetailResponse {
             .endDate(poll.getEndDate())
             .commentCount(commentCount)
             .routes(routes)
+            .teamId(poll.getTeam().getId())
             .build();
     }
 }

--- a/src/main/java/com/saerok/showing/api/domain/poll/entity/Poll.java
+++ b/src/main/java/com/saerok/showing/api/domain/poll/entity/Poll.java
@@ -4,10 +4,10 @@ import com.saerok.showing.api.domain.member.entity.Member;
 import com.saerok.showing.api.domain.poll.dto.request.PollCreateRequest;
 import com.saerok.showing.api.domain.poll.dto.request.PollUpdateRequest;
 import com.saerok.showing.api.domain.route.entity.Route;
+import com.saerok.showing.api.domain.team.entity.Team;
 import com.saerok.showing.api.global.entity.BaseEntity;
 import com.saerok.showing.api.global.exception.ErrorCode;
 import com.saerok.showing.api.global.exception.ShowingException;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -64,7 +64,11 @@ public class Poll extends BaseEntity {
     @OneToMany(mappedBy = "poll")
     private List<Route> routeOptions = new ArrayList<>();
 
-    public static Poll toEntity(PollCreateRequest request, Member member) {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id", nullable = false)
+    private Team team;
+
+    public static Poll toEntity(PollCreateRequest request, Member member, Team team) {
         return Poll.builder()
             .title(request.getTitle())
             .pollStatus(request.getPollStatus())
@@ -72,6 +76,7 @@ public class Poll extends BaseEntity {
             .endDate(request.getEndDate())
             .likeCount(0)
             .member(member)
+            .team(team)
             .build();
     }
 

--- a/src/main/java/com/saerok/showing/api/domain/poll/service/PollService.java
+++ b/src/main/java/com/saerok/showing/api/domain/poll/service/PollService.java
@@ -1,6 +1,7 @@
 package com.saerok.showing.api.domain.poll.service;
 
 import com.saerok.showing.api.domain.member.entity.Member;
+import com.saerok.showing.api.domain.memberTeam.service.MemberTeamService;
 import com.saerok.showing.api.domain.place.dto.response.PlaceSummaryResponse;
 import com.saerok.showing.api.domain.poll.dto.request.PollCandidateRegisterRequest;
 import com.saerok.showing.api.domain.poll.dto.request.PollCreateRequest;
@@ -11,6 +12,8 @@ import com.saerok.showing.api.domain.poll.repository.PollRepository;
 import com.saerok.showing.api.domain.route.dto.response.RouteSummaryResponse;
 import com.saerok.showing.api.domain.route.entity.Route;
 import com.saerok.showing.api.domain.route.service.RouteService;
+import com.saerok.showing.api.domain.team.entity.Team;
+import com.saerok.showing.api.domain.team.service.TeamService;
 import com.saerok.showing.api.global.auth.util.LoginMemberProvider;
 import com.saerok.showing.api.global.exception.ErrorCode;
 import com.saerok.showing.api.global.exception.ShowingException;
@@ -24,13 +27,17 @@ import org.springframework.transaction.annotation.Transactional;
 public class PollService {
 
     private final PollRepository pollRepository;
-    private final LoginMemberProvider loginMemberProvider;
+    private final TeamService teamService;
     private final RouteService routeService;
+    private final MemberTeamService memberTeamService;
+    private final LoginMemberProvider loginMemberProvider;
 
     @Transactional
     public Long save(PollCreateRequest request) {
         Member member = loginMemberProvider.getCurrentLoginMember();
-        Poll poll = Poll.toEntity(request, member);
+        Team team = teamService.findById(request.getTeamId());
+        Poll poll = Poll.toEntity(request, member, team);
+        validateTeamMember(poll, member);
         pollRepository.save(poll);
         return poll.getId();
     }
@@ -54,6 +61,7 @@ public class PollService {
     public void registerCandidate(Long pollId, PollCandidateRegisterRequest request) {
         Member member = loginMemberProvider.getCurrentLoginMember();
         Poll poll = findById(pollId);
+        validateTeamMember(poll, member);
         Route route = routeService.findById(request.getRouteId());
         poll.registerRouteOption(route);
     }
@@ -62,6 +70,7 @@ public class PollService {
     public Long update(Long pollId, PollUpdateRequest request) {
         Member member = loginMemberProvider.getCurrentLoginMember();
         Poll poll = findById(pollId);
+        validateTeamMember(poll, member);
         poll.validateOwner(poll, member);
         poll.update(request);
         return poll.getId();
@@ -71,9 +80,16 @@ public class PollService {
     public Long delete(Long pollId) {
         Member member = loginMemberProvider.getCurrentLoginMember();
         Poll poll = findById(pollId);
+        validateTeamMember(poll, member);
         poll.validateOwner(poll, member);
         pollRepository.delete(poll);
         return pollId;
+    }
+
+    private void validateTeamMember(Poll poll, Member member) {
+        if (!memberTeamService.existsByMemberIdAndTeamId(member.getId(), poll.getTeam().getId())) {
+            throw ShowingException.from(ErrorCode.NOT_MEMBER_OF_TEAM);
+        }
     }
 
     private int getCommentCount(Long pollId) {


### PR DESCRIPTION
## ⭐️ Overview

> #75 

투표 기능을 팀 소속 멤버만 조회 및 참여할 수 있도록 권한 제한 로직을 추가하고, 전체 로직을 리팩토링했습니다.

## 🔧 Tasks

- 투표 생성 시 `teamId` 필드 고려하여 Poll 엔티티 생성 방식 수정
- 투표 조회 시 로그인 유저가 해당 팀 소속인지 검증
- 투표 후보지 등록 시 팀 소속 여부 확인 및 예외 처리
- 기존 투표 API 동작과의 호환성 검토 및 예외 처리 보강

## 📝 Additional Notes

- 하나의 멤버가 여러 팀에 소속될 수 있는 구조를 고려했습니다.

## 📸 Screenshot

### 투표 생성
<img width="700" alt="투표 생성" src="https://github.com/user-attachments/assets/565b2a9f-9566-4d63-9a5d-8af0f3314ada" />

### 투표 후보지 등록
<img width="700" alt="투표 후보지 등록" src="https://github.com/user-attachments/assets/14e683f8-b83a-49f8-b89e-5c0faee88749" />

### 투표 조회
<img width="700" alt="투표 조회1" src="https://github.com/user-attachments/assets/b52a4fc3-13ab-409e-bd86-9f242535832d" />
<img width="700" alt="투표 조회2" src="https://github.com/user-attachments/assets/f2070c8c-e7f8-4b27-89e4-3c3d4b8efcd9" />
