### PR TITLE
refactor: 투표 삭제 오류 해결 및 여행 코스 조회 시 테마id 필드를 추가

### DIFF
--- a/src/main/java/com/saerok/showing/api/domain/comment/entity/Comment.java
+++ b/src/main/java/com/saerok/showing/api/domain/comment/entity/Comment.java
@@ -1,5 +1,6 @@
 package com.saerok.showing.api.domain.comment.entity;
 
+import com.saerok.showing.api.domain.like.entity.Like;
 import com.saerok.showing.api.domain.member.entity.Member;
 import com.saerok.showing.api.domain.comment.dto.request.CommentCreateRequest;
 import com.saerok.showing.api.domain.poll.entity.Poll;
@@ -7,6 +8,7 @@ import com.saerok.showing.api.domain.post.entity.Post;
 import com.saerok.showing.api.global.entity.BaseEntity;
 import com.saerok.showing.api.global.exception.ErrorCode;
 import com.saerok.showing.api.global.exception.ShowingException;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -15,7 +17,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -54,6 +59,9 @@ public class Comment extends BaseEntity {
     @Column(name = "like_count", nullable = false)
     private int likeCount;
 
+    @OneToMany(mappedBy = "comment", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Like> likes = new ArrayList<>();
+
     public static Comment toEntity(Member member, Post post, CommentCreateRequest request) {
         return Comment.builder()
             .member(member)
@@ -77,5 +85,10 @@ public class Comment extends BaseEntity {
         if (this.likeCount > 0) {
             this.likeCount--;
         }
+    }
+
+    public void addLike(Like like) {
+        likes.add(like);
+        like.setComment(this);
     }
 }

--- a/src/main/java/com/saerok/showing/api/domain/like/entity/Like.java
+++ b/src/main/java/com/saerok/showing/api/domain/like/entity/Like.java
@@ -1,7 +1,9 @@
 package com.saerok.showing.api.domain.like.entity;
 
+import com.saerok.showing.api.domain.comment.entity.Comment;
 import com.saerok.showing.api.domain.like.dto.request.LikeToggleRequest;
 import com.saerok.showing.api.domain.member.entity.Member;
+import com.saerok.showing.api.domain.post.entity.Post;
 import com.saerok.showing.api.global.entity.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -10,6 +12,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -40,11 +43,35 @@ public class Like extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private LikeTargetType targetType;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+
     public static Like toEntity(Member member, LikeToggleRequest request) {
         return Like.builder()
             .member(member)
             .targetId(request.getTargetId())
             .targetType(request.getLikeTargetType())
             .build();
+    }
+
+    public static Like forPost(Member member, Post post) {
+        Like like = new Like();
+        like.setMember(member);
+        like.setPost(post);
+        post.getLikes().add(like);
+        return like;
+    }
+
+    public static Like forComment(Member member, Comment comment) {
+        Like like = new Like();
+        like.setMember(member);
+        like.setComment(comment);
+        comment.getLikes().add(like);
+        return like;
     }
 }

--- a/src/main/java/com/saerok/showing/api/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/saerok/showing/api/domain/like/repository/LikeRepository.java
@@ -1,12 +1,18 @@
 package com.saerok.showing.api.domain.like.repository;
 
+import com.saerok.showing.api.domain.comment.entity.Comment;
 import com.saerok.showing.api.domain.like.entity.LikeTargetType;
 import com.saerok.showing.api.domain.member.entity.Member;
 import com.saerok.showing.api.domain.like.entity.Like;
+import com.saerok.showing.api.domain.post.entity.Post;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
+
+    Optional<Like> findByMemberAndPost(Member member, Post post);
+
+    Optional<Like> findByMemberAndComment(Member member, Comment comment);
 
     Optional<Like> findByMemberAndTargetIdAndTargetType(Member member, Long targetId, LikeTargetType targetType);
 }

--- a/src/main/java/com/saerok/showing/api/domain/like/service/LikeService.java
+++ b/src/main/java/com/saerok/showing/api/domain/like/service/LikeService.java
@@ -48,29 +48,25 @@ public class LikeService {
     }
 
     private boolean handleToggle(Member member, LikeToggleRequest request, Post post) {
-        Optional<Like> existingLike = likeRepository.findByMemberAndTargetIdAndTargetType(
-            member, request.getTargetId(), LikeTargetType.POST
-        );
+        Optional<Like> existingLike = likeRepository.findByMemberAndPost(member, post);
         if (existingLike.isPresent()) {
             likeRepository.delete(existingLike.get());
             post.decreaseLikeCount();
             return false;
         }
-        likeRepository.save(Like.toEntity(member, request));
+        likeRepository.save(Like.forPost(member, post));
         post.increaseLikeCount();
         return true;
     }
 
     private boolean handleToggle(Member member, LikeToggleRequest request, Comment comment) {
-        Optional<Like> existingLike = likeRepository.findByMemberAndTargetIdAndTargetType(
-            member, request.getTargetId(), LikeTargetType.COMMENT
-        );
+        Optional<Like> existingLike = likeRepository.findByMemberAndComment(member, comment);
         if (existingLike.isPresent()) {
             likeRepository.delete(existingLike.get());
             comment.decreaseLikeCount();
             return false;
         }
-        likeRepository.save(Like.toEntity(member, request));
+        likeRepository.save(Like.forComment(member, comment));
         comment.increaseLikeCount();
         return true;
     }

--- a/src/main/java/com/saerok/showing/api/domain/poll/controller/PollController.java
+++ b/src/main/java/com/saerok/showing/api/domain/poll/controller/PollController.java
@@ -33,7 +33,8 @@ public class PollController {
         summary = "투표 등록",
         description = """
             [모든 Role 가능] 새 투표를 등록합니다.<br>
-            투표 등록 시, 반드시 teamId를 입력해야하며, 해당 투표 조회와 후보지 등록은 팀원만 가능합니다.
+            투표 등록 시, 반드시 teamId를 입력해야하며, 해당 투표 조회와 후보지 등록은 팀원만 가능합니다.<br>
+            투표 상태로는 READY(대기중), ONGOING(진행중), CLOSED(종료됨)가 있습니다.
             """
     )
     @PreAuthorize("hasRole('MEMBER')")

--- a/src/main/java/com/saerok/showing/api/domain/poll/entity/Poll.java
+++ b/src/main/java/com/saerok/showing/api/domain/poll/entity/Poll.java
@@ -1,15 +1,20 @@
 package com.saerok.showing.api.domain.poll.entity;
 
+import com.saerok.showing.api.domain.comment.entity.Comment;
 import com.saerok.showing.api.domain.member.entity.Member;
 import com.saerok.showing.api.domain.poll.dto.request.PollCreateRequest;
 import com.saerok.showing.api.domain.poll.dto.request.PollUpdateRequest;
+import com.saerok.showing.api.domain.post.entity.Post;
 import com.saerok.showing.api.domain.route.entity.Route;
 import com.saerok.showing.api.domain.team.entity.Team;
 import com.saerok.showing.api.global.entity.BaseEntity;
 import com.saerok.showing.api.global.exception.ErrorCode;
 import com.saerok.showing.api.global.exception.ShowingException;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -45,6 +50,7 @@ public class Poll extends BaseEntity {
     @Column(name = "title", nullable = false)
     private String title;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "poll_type", nullable = false)
     private PollStatus pollStatus;
 
@@ -61,8 +67,14 @@ public class Poll extends BaseEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    @OneToMany(mappedBy = "poll")
+    @OneToMany(mappedBy = "poll", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Route> routeOptions = new ArrayList<>();
+
+    @OneToMany(mappedBy = "poll", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Post> posts = new ArrayList<>();
+
+    @OneToMany(mappedBy = "poll", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> comments = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_id", nullable = false)

--- a/src/main/java/com/saerok/showing/api/domain/poll/service/PollService.java
+++ b/src/main/java/com/saerok/showing/api/domain/poll/service/PollService.java
@@ -98,6 +98,7 @@ public class PollService {
         Poll poll = findById(pollId);
         validateTeamMember(poll, member);
         poll.validateOwner(poll, member);
+        poll.getRouteOptions().forEach(route -> route.setPoll(null));
         pollRepository.delete(poll);
         return pollId;
     }

--- a/src/main/java/com/saerok/showing/api/domain/post/controller/PostController.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/controller/PostController.java
@@ -38,6 +38,7 @@ public class PostController {
             [모든 Role 가능] 게시글을 작성합니다.<br>
             요청 본문에는 제목, 내용, 게시글 타입, 게시글 이미지(리스트), 해시태그(리스트), 팀id가 포함됩니다.<br>
             게시글 이미지는 "/api/v1/file/post"를 이용하여 얻은 fileUrl값들을 입력해주세요.<br>
+            게시글 타입은 NORMAL(일반), POLL(투표 내 게시글)이 가능합니다.<br>
             전체 공개는 VISIBLE_ALL, 팀만 공개는 TEAM_ONLY로 visibility를 지정해주세요.<br>
             전체 공개 시에는 팀id 필드를 null로 주시면 됩니다.<br>
             팀이 여러 개인 경우 어느 팀에만 공개하는 게시글인지 해당 팀의 fk가 필요합니다.

--- a/src/main/java/com/saerok/showing/api/domain/post/entity/Post.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/entity/Post.java
@@ -1,6 +1,9 @@
 package com.saerok.showing.api.domain.post.entity;
 
+import com.saerok.showing.api.domain.comment.entity.Comment;
+import com.saerok.showing.api.domain.like.entity.Like;
 import com.saerok.showing.api.domain.member.entity.Member;
+import com.saerok.showing.api.domain.poll.entity.Poll;
 import com.saerok.showing.api.domain.post.dto.request.PostCreateRequest;
 import com.saerok.showing.api.domain.post.dto.request.PostUpdateRequest;
 import com.saerok.showing.api.domain.team.entity.Team;
@@ -8,6 +11,7 @@ import com.saerok.showing.api.global.entity.BaseEntity;
 import com.saerok.showing.api.global.exception.ErrorCode;
 import com.saerok.showing.api.global.exception.ShowingException;
 import com.saerok.showing.api.global.file.entity.UploadedFile;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
@@ -75,9 +79,19 @@ public class Post extends BaseEntity {
     @Column(name = "like_count", nullable = false)
     private int likeCount;
 
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> comments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Like> likes = new ArrayList<>();
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_id")
     private Team team;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "poll_id")
+    private Poll poll;
 
     public static Post toEntity(Member member, PostCreateRequest request, List<UploadedFile> files, Team team) {
         Post post = Post.builder()
@@ -118,6 +132,11 @@ public class Post extends BaseEntity {
         if (this.likeCount > 0) {
             this.likeCount--;
         }
+    }
+
+    public void addLike(Like like) {
+        likes.add(like);
+        like.setPost(this);
     }
 
     private void validateVisibilityInvariant() {

--- a/src/main/java/com/saerok/showing/api/domain/route/dto/response/RouteSummaryResponse.java
+++ b/src/main/java/com/saerok/showing/api/domain/route/dto/response/RouteSummaryResponse.java
@@ -23,6 +23,8 @@ public class RouteSummaryResponse {
 
     private int likeCount;
 
+    private Long themeId;
+
     public static RouteSummaryResponse toDto(Route route, List<PlaceSummaryResponse> placeSummaries) {
         return RouteSummaryResponse.builder()
             .id(route.getId())
@@ -31,6 +33,7 @@ public class RouteSummaryResponse {
             .endDate(route.getEndDate())
             .placeSummaries(placeSummaries)
             .likeCount(route.getLikeCount())
+            .themeId(route.getThemeId())
             .build();
     }
 }


### PR DESCRIPTION
## ⭐️ Overview

> #79

투표 삭제 시 발생하던 오류를 해결하고, 여행 코스 조회 시 `themeId` 필드를 추가했습니다.
또한 엔티티 전반의 연관관계 매핑을 점검 및 보완했습니다.

## 🔧 Tasks

- 투표 삭제 오류 해결  
- 여행 코스 조회 응답에 `themeId` 필드 추가  
- 게시글(`Post`) 연관관계 매핑 점검 및 수정  
- 투표(`Poll`) 연관관계 매핑 점검 및 수정 

## 📝 Additional Notes

- 연관관계 매핑 관련 오류는 다음 과정을 거치며 발견되었습니다.  
  **[팀 생성] → [투표 등록] → [여행 코스 생성] → [여행 코스 내 장소 추가] → [투표 여행 코스 후보지 등록] → [여행 코스 삭제]**  

- 이에 따라 엔티티 전반의 연관관계 매핑을 점검 및 수정했습니다.  


## 📸 Screenshot

### 투표 삭제
<img width="600" alt="투표 삭제" src="https://github.com/user-attachments/assets/bdb6d929-23de-478e-8f2a-c3aaf4feb94f" />

### 여행코스 조회
<img width="600" alt="여행코스 조회" src="https://github.com/user-attachments/assets/af0d72e4-bb4e-4667-b38e-995f0c1d18ea" />
