### PR TITLE
refactor: 로그인한 사용자의 좋아요 유무 필드 추가 및 마이페이지 리팩토링

### DIFF
--- a/src/main/java/com/saerok/showing/api/domain/like/controller/LikeController.java
+++ b/src/main/java/com/saerok/showing/api/domain/like/controller/LikeController.java
@@ -25,7 +25,7 @@ public class LikeController {
         summary = "좋아요 토글 (게시글/댓글)",
         description = """
             [모든 Role 가능] 좋아요 토글입니다.<br>
-            좋아요 대상은 POST(게시글), COMMENT(댓글), ROUTE(여행 경로), POLL(투표 그 자체), POLL_ROUTE(투표 내 여행경로) 5가지입니다.<br>
+            좋아요 대상은 POST(게시글), COMMENT(댓글), ROUTE(여행 경로), POLL(투표 그 자체), POLL_OPTION(투표 내 여행경로) 5가지입니다.<br>
             좋아요 된 대상을 다시 토글하게 되면 좋아요가 취소됩니다.<br>
             true 반환인 경우 좋아요 등록, false 반환은 좋아요 취소입니다.
             """

--- a/src/main/java/com/saerok/showing/api/domain/like/entity/Like.java
+++ b/src/main/java/com/saerok/showing/api/domain/like/entity/Like.java
@@ -59,17 +59,24 @@ public class Like extends BaseEntity {
             .build();
     }
 
-    public static Like forPost(Member member, Post post) {
-        Like like = new Like();
-        like.setMember(member);
+    public static Like forPost(Member member, LikeToggleRequest request, Post post) {
+        Like like = Like.builder()
+            .member(member)
+            .targetId(request.getTargetId())
+            .targetType(request.getLikeTargetType())
+            .build();
         like.setPost(post);
         post.getLikes().add(like);
         return like;
     }
 
-    public static Like forComment(Member member, Comment comment) {
-        Like like = new Like();
-        like.setMember(member);
+
+    public static Like forComment(Member member, LikeToggleRequest request, Comment comment) {
+        Like like = Like.builder()
+            .member(member)
+            .targetId(request.getTargetId())
+            .targetType(request.getLikeTargetType())
+            .build();
         like.setComment(comment);
         comment.getLikes().add(like);
         return like;

--- a/src/main/java/com/saerok/showing/api/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/saerok/showing/api/domain/like/repository/LikeRepository.java
@@ -5,6 +5,7 @@ import com.saerok.showing.api.domain.like.entity.LikeTargetType;
 import com.saerok.showing.api.domain.member.entity.Member;
 import com.saerok.showing.api.domain.like.entity.Like;
 import com.saerok.showing.api.domain.post.entity.Post;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -13,6 +14,8 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
     Optional<Like> findByMemberAndPost(Member member, Post post);
 
     Optional<Like> findByMemberAndComment(Member member, Comment comment);
+
+    List<Like> findByMemberAndTargetType(Member member, LikeTargetType targetType);
 
     Optional<Like> findByMemberAndTargetIdAndTargetType(Member member, Long targetId, LikeTargetType targetType);
 }

--- a/src/main/java/com/saerok/showing/api/domain/like/service/LikeReadService.java
+++ b/src/main/java/com/saerok/showing/api/domain/like/service/LikeReadService.java
@@ -1,8 +1,11 @@
 package com.saerok.showing.api.domain.like.service;
 
+import com.saerok.showing.api.domain.like.entity.Like;
 import com.saerok.showing.api.domain.like.entity.LikeTargetType;
 import com.saerok.showing.api.domain.like.repository.LikeRepository;
 import com.saerok.showing.api.domain.member.entity.Member;
+import com.saerok.showing.api.domain.post.entity.Post;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,5 +39,12 @@ public class LikeReadService {
     @Transactional(readOnly = true)
     public boolean isPollOptionLiked(Member member, Long pollOptionId) {
         return likeRepository.findByMemberAndTargetIdAndTargetType(member, pollOptionId, LikeTargetType.POLL_OPTION).isPresent();
+    }
+
+    @Transactional(readOnly = true)
+    public List<Post> getLikedPosts(Member member) {
+        return likeRepository.findByMemberAndTargetType(member, LikeTargetType.POST).stream()
+            .map(Like::getPost)
+            .toList();
     }
 }

--- a/src/main/java/com/saerok/showing/api/domain/like/service/LikeReadService.java
+++ b/src/main/java/com/saerok/showing/api/domain/like/service/LikeReadService.java
@@ -22,4 +22,19 @@ public class LikeReadService {
     public boolean isCommentLiked(Member member, Long commentId) {
         return likeRepository.findByMemberAndTargetIdAndTargetType(member, commentId, LikeTargetType.COMMENT).isPresent();
     }
+
+    @Transactional(readOnly = true)
+    public boolean isRouteLiked(Member member, Long routeId) {
+        return likeRepository.findByMemberAndTargetIdAndTargetType(member, routeId, LikeTargetType.ROUTE).isPresent();
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isPollLiked(Member member, Long pollId) {
+        return likeRepository.findByMemberAndTargetIdAndTargetType(member, pollId, LikeTargetType.POLL).isPresent();
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isPollOptionLiked(Member member, Long pollOptionId) {
+        return likeRepository.findByMemberAndTargetIdAndTargetType(member, pollOptionId, LikeTargetType.POLL_OPTION).isPresent();
+    }
 }

--- a/src/main/java/com/saerok/showing/api/domain/like/service/LikeService.java
+++ b/src/main/java/com/saerok/showing/api/domain/like/service/LikeService.java
@@ -54,7 +54,7 @@ public class LikeService {
             post.decreaseLikeCount();
             return false;
         }
-        likeRepository.save(Like.forPost(member, post));
+        likeRepository.save(Like.forPost(member, request, post));
         post.increaseLikeCount();
         return true;
     }
@@ -66,7 +66,7 @@ public class LikeService {
             comment.decreaseLikeCount();
             return false;
         }
-        likeRepository.save(Like.forComment(member, comment));
+        likeRepository.save(Like.forComment(member, request, comment));
         comment.increaseLikeCount();
         return true;
     }

--- a/src/main/java/com/saerok/showing/api/domain/member/dto/response/MyPageResponse.java
+++ b/src/main/java/com/saerok/showing/api/domain/member/dto/response/MyPageResponse.java
@@ -1,6 +1,7 @@
 package com.saerok.showing.api.domain.member.dto.response;
 
 import com.saerok.showing.api.domain.member.entity.Member;
+import com.saerok.showing.api.domain.post.dto.response.PostSummaryResponse;
 import com.saerok.showing.api.domain.route.dto.response.RouteSummaryResponse;
 import java.util.List;
 import lombok.Builder;
@@ -20,10 +21,13 @@ public class MyPageResponse {
 
     private List<RouteSummaryResponse> routes;
 
+    private List<PostSummaryResponse> posts;
+
     public static MyPageResponse toDto(
         Member member,
         int postCount,
-        List<RouteSummaryResponse> routes
+        List<RouteSummaryResponse> routes,
+        List<PostSummaryResponse> posts
     ) {
         return MyPageResponse.builder()
             .name(member.getName())
@@ -31,6 +35,7 @@ public class MyPageResponse {
             .profileImage(member.getProfileImage())
             .postCount(postCount)
             .routes(routes)
+            .posts(posts)
             .build();
     }
 }

--- a/src/main/java/com/saerok/showing/api/domain/member/service/MemberService.java
+++ b/src/main/java/com/saerok/showing/api/domain/member/service/MemberService.java
@@ -4,6 +4,7 @@ import com.saerok.showing.api.domain.member.dto.request.MemberUpdateRequest;
 import com.saerok.showing.api.domain.member.dto.response.MyPageResponse;
 import com.saerok.showing.api.domain.member.entity.Member;
 import com.saerok.showing.api.domain.member.repository.MemberRepository;
+import com.saerok.showing.api.domain.post.dto.response.PostSummaryResponse;
 import com.saerok.showing.api.domain.post.service.PostService;
 import com.saerok.showing.api.domain.route.dto.response.RouteSummaryResponse;
 import com.saerok.showing.api.domain.route.service.RouteService;
@@ -29,7 +30,8 @@ public class MemberService {
         Member member = loginMemberProvider.getCurrentLoginMember();
         int postCount = postService.getPostCount();
         List<RouteSummaryResponse> routes = routeService.getMyRouteSummaries();
-        return MyPageResponse.toDto(member, postCount, routes);
+        List<PostSummaryResponse> posts = postService.getMyLikesPostSummaries();
+        return MyPageResponse.toDto(member, postCount, routes, posts);
     }
 
     @Transactional

--- a/src/main/java/com/saerok/showing/api/domain/poll/dto/response/PollDetailResponse.java
+++ b/src/main/java/com/saerok/showing/api/domain/poll/dto/response/PollDetailResponse.java
@@ -33,11 +33,14 @@ public class PollDetailResponse {
 
     private Long teamId;
 
+    private boolean isLiked;
+
     public static PollDetailResponse toDto(
         Poll poll,
         Member member,
         int commentCount,
-        List<RouteSummaryResponse> routes
+        List<RouteSummaryResponse> routes,
+        boolean isLiked
     ) {
         return PollDetailResponse.builder()
             .id(poll.getId())
@@ -50,6 +53,7 @@ public class PollDetailResponse {
             .commentCount(commentCount)
             .routes(routes)
             .teamId(poll.getTeam().getId())
+            .isLiked(isLiked)
             .build();
     }
 }

--- a/src/main/java/com/saerok/showing/api/domain/poll/service/PollService.java
+++ b/src/main/java/com/saerok/showing/api/domain/poll/service/PollService.java
@@ -1,5 +1,6 @@
 package com.saerok.showing.api.domain.poll.service;
 
+import com.saerok.showing.api.domain.like.service.LikeReadService;
 import com.saerok.showing.api.domain.member.entity.Member;
 import com.saerok.showing.api.domain.memberTeam.service.MemberTeamService;
 import com.saerok.showing.api.domain.place.dto.response.PlaceSummaryResponse;
@@ -28,6 +29,7 @@ public class PollService {
 
     private final PollRepository pollRepository;
     private final TeamService teamService;
+    private final LikeReadService likeReadService;
     private final RouteService routeService;
     private final MemberTeamService memberTeamService;
     private final LoginMemberProvider loginMemberProvider;
@@ -44,33 +46,40 @@ public class PollService {
 
     @Transactional(readOnly = true)
     public List<PollDetailResponse> getTeamPolls(Long teamId) {
-        Long memberId = loginMemberProvider.getCurrentLoginMemberId();
-        validateTeamMember(teamId, memberId);
+        Member member = loginMemberProvider.getCurrentLoginMember();
+        validateTeamMember(teamId, member.getId());
         return pollRepository.findAllByTeamId(teamId)
             .stream()
             .map(poll -> {
                 int commentCount = pollRepository.countCommentsOfPoll(poll.getId());
                 List<RouteSummaryResponse> routeSummaries = poll.getRouteOptions().stream()
-                    .map(route -> RouteSummaryResponse.toDto(route, List.of()))
+                    .map(route -> {
+                        boolean isPollOptionLiked = likeReadService.isPollOptionLiked(member, route.getId());
+                        return RouteSummaryResponse.toDto(route, List.of(), isPollOptionLiked);
+                    })
                     .toList();
-                return PollDetailResponse.toDto(poll, poll.getMember(), commentCount, routeSummaries);
+                boolean isLiked = likeReadService.isPollLiked(member, poll.getId());
+                return PollDetailResponse.toDto(poll, poll.getMember(), commentCount, routeSummaries, isLiked);
             })
             .toList();
     }
 
     @Transactional(readOnly = true)
     public PollDetailResponse getPoll(Long pollId) {
+        Member member = loginMemberProvider.getCurrentLoginMember();
         Poll poll = findById(pollId);
         int commentCount = getCommentCount(pollId);
         List<RouteSummaryResponse> routeSummaries = poll.getRouteOptions().stream()
             .map(route -> {
+                boolean isPollOptionLiked = likeReadService.isPollOptionLiked(member, route.getId());
                 List<PlaceSummaryResponse> placeSummaries = route.getRoutePlaces().stream()
                     .map(routePlace -> PlaceSummaryResponse.create(routePlace.getPlaceName()))
                     .toList();
-                return RouteSummaryResponse.toDto(route, placeSummaries);
+                return RouteSummaryResponse.toDto(route, placeSummaries, isPollOptionLiked);
             })
             .toList();
-        return PollDetailResponse.toDto(poll, poll.getMember(), commentCount, routeSummaries);
+        boolean isLiked = likeReadService.isPollLiked(member, pollId);
+        return PollDetailResponse.toDto(poll, poll.getMember(), commentCount, routeSummaries, isLiked);
     }
 
     @Transactional

--- a/src/main/java/com/saerok/showing/api/domain/post/service/PostService.java
+++ b/src/main/java/com/saerok/showing/api/domain/post/service/PostService.java
@@ -84,6 +84,18 @@ public class PostService {
         );
     }
 
+    @Transactional(readOnly = true)
+    public List<PostSummaryResponse> getMyLikesPostSummaries() {
+        Member member = loginMemberProvider.getCurrentLoginMember();
+        return likeReadService.getLikedPosts(member).stream()
+            .map(post -> PostSummaryResponse.toDto(
+                post,
+                post.getComments().size(),
+                true
+            ))
+            .toList();
+    }
+
     @Transactional
     public Long update(Long postId, PostUpdateRequest request) {
         Member member = loginMemberProvider.getCurrentLoginMember();

--- a/src/main/java/com/saerok/showing/api/domain/route/dto/response/RouteSummaryResponse.java
+++ b/src/main/java/com/saerok/showing/api/domain/route/dto/response/RouteSummaryResponse.java
@@ -29,7 +29,9 @@ public class RouteSummaryResponse {
 
     private Long themeId;
 
-    public static RouteSummaryResponse toDto(Route route, List<PlaceSummaryResponse> placeSummaries) {
+    private boolean liked;
+
+    public static RouteSummaryResponse toDto(Route route, List<PlaceSummaryResponse> placeSummaries, boolean liked) {
         return RouteSummaryResponse.builder()
             .id(route.getId())
             .writerName(route.getMember().getName())
@@ -40,6 +42,7 @@ public class RouteSummaryResponse {
             .placeSummaries(placeSummaries)
             .likeCount(route.getLikeCount())
             .themeId(route.getThemeId())
+            .liked(liked)
             .build();
     }
 }

--- a/src/main/java/com/saerok/showing/api/domain/route/service/RouteService.java
+++ b/src/main/java/com/saerok/showing/api/domain/route/service/RouteService.java
@@ -1,5 +1,6 @@
 package com.saerok.showing.api.domain.route.service;
 
+import com.saerok.showing.api.domain.like.service.LikeReadService;
 import com.saerok.showing.api.domain.member.entity.Member;
 import com.saerok.showing.api.domain.place.dto.response.PlaceSummaryResponse;
 import com.saerok.showing.api.domain.route.dto.request.RouteCreateRequest;
@@ -22,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class RouteService {
 
     private final RouteRepository routeRepository;
+    private final LikeReadService likeReadService;
     private final LoginMemberProvider loginMemberProvider;
 
     @Transactional
@@ -53,8 +55,8 @@ public class RouteService {
                     .limit(3)
                     .map(routePlace -> PlaceSummaryResponse.create(routePlace.getPlaceName()))
                     .toList();
-
-                return RouteSummaryResponse.toDto(route, topPlaces);
+                boolean isLiked = likeReadService.isRouteLiked(member, route.getId());
+                return RouteSummaryResponse.toDto(route, topPlaces, isLiked);
             })
             .toList();
     }

--- a/src/main/java/com/saerok/showing/api/domain/routePlace/dto/response/RoutePlaceBoxResponse.java
+++ b/src/main/java/com/saerok/showing/api/domain/routePlace/dto/response/RoutePlaceBoxResponse.java
@@ -1,7 +1,6 @@
 package com.saerok.showing.api.domain.routePlace.dto.response;
 
 import com.saerok.showing.api.domain.routePlace.entity.RoutePlace;
-import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 


### PR DESCRIPTION
## ⭐️ Overview

> #82 

현재 로그인한 사용자의 좋아요 유무(`isLiked`) 필드 전반을 리팩토링했습니다.  
또한, 마이페이지 조회 시 내가 좋아요한 게시글 리스트도 함께 반환되도록 개선했습니다.

## 🔧 Tasks

- 게시글(Post) 좋아요 여부(`isLiked`) 필드 추가
- 댓글(Comment) 좋아요 여부(`isLiked`) 필드 추가
- 여행 경로(Route) 좋아요 여부(`isLiked`) 필드 추가
- 투표(Poll) 좋아요 여부(`isLiked`) 필드 추가
- 투표 내 여행 경로(PollRoute) 좋아요 여부(`isLiked`) 필드 추가
- 마이페이지 조회 시 내가 좋아요한 게시글 리스트 반환 로직 추가

## 📝 Additional Notes

- 일반 게시글/댓글/여행 경로 조회 시에는 `LikeReadService`를 통해 로그인 사용자 기준으로 `isLiked` 값을 계산합니다.  
- 투표 내 여행 경로 좋아요(`PollRoute`)와 일반 여행 경로 좋아요(`Route`)는 서로 다른 개념이므로 별도의 타입으로 구분되어 저장됩니다.  

## 📸 Screenshot

### 게시글 조회
<img width="700" alt="전체 게시글 조회" src="https://github.com/user-attachments/assets/1742f623-2851-4d2b-a42e-3da9539d8ff3" />
<img width="700" alt="단건 게시글 조회" src="https://github.com/user-attachments/assets/fa88c8e5-95f2-41c4-81a0-34fff07f160b" />

### 댓글 조회
<img width="700" alt="댓글 조회" src="https://github.com/user-attachments/assets/10096967-3fc5-4f41-a589-09c7a4999cbc" />

### 투표 조회
<img width="700" alt="투표 조회" src="https://github.com/user-attachments/assets/6a8cc6f7-f61f-4ec8-aeb5-548f5741f14e" />

### 투표 내 여행 경로 조회
<img width="700" alt="투표 내 여행 경로 조회" src="https://github.com/user-attachments/assets/9b47e9cc-c9bd-4501-a644-be4f6df5542f" />

### 마이페이지 조회
<img width="700" alt="마이페이지 조회" src="https://github.com/user-attachments/assets/0563fbfe-dd5e-49d2-8b67-8a4e1a5a7a98" />

